### PR TITLE
Fix isset in port mapping detection and update the whole bit

### DIFF
--- a/src/BusinessCase/Comparison/MarathonJobComparisonBusinessCase.php
+++ b/src/BusinessCase/Comparison/MarathonJobComparisonBusinessCase.php
@@ -51,27 +51,36 @@ class MarathonJobComparisonBusinessCase extends AbstractJobComparisionBusinessCa
         if ($localJob->container && $localJob->container->docker &&
             $remoteJob->container && $remoteJob->container->docker) {
 
-            foreach ($localJob->container->docker->portMappings as $index => $localPortMapping) {
+            $localPortMappings = $localJob->container->docker->portMappings;
+            $remotePortMappings = $remoteJob->container->docker->portMappings;
+
+            usort($localPortMappings, DockerPortMapping::class . '::less');
+            usort($remotePortMappings, DockerPortMapping::class . '::less');
+
+            foreach ($localPortMappings as $index => $localPortMapping) {
                 if ($localPortMapping->servicePort !== 0) {
                     continue;
                 }
 
-                if (!isset($remoteJob->container->docker->portMappings[$index])) {
+                if (!isset($remotePortMappings[$index])) {
                     continue;
                 }
 
-                $remotePortMapping = $remoteJob->container->docker->portMappings[$index];
+                $remotePortMapping = $remotePortMappings[$index];
 
-                if ($remotePortMapping != $localPortMapping) {
+                if (DockerPortMapping::less($remotePortMapping, $localPortMapping) != 0) {
                     $fixedPortMapping = clone $remotePortMapping;
                     $fixedPortMapping->servicePort = 0;
 
-                    if ($fixedPortMapping == $localPortMapping) {
-                        unset($localJob->container->docker->portMappings[$index]);
-                        unset($remoteJob->container->docker->portMappings[$index]);
+                    if (DockerPortMapping::less($fixedPortMapping, $localPortMapping) == 0) {
+                        unset($localPortMappings[$index]);
+                        unset($remotePortMappings[$index]);
                     }
                 }
             }
+
+            $localJob->container->docker->portMappings = array_values($localPortMappings);
+            $remoteJob->container->docker->portMappings = array_values($remotePortMappings);
         }
     }
 

--- a/src/BusinessCase/Comparison/MarathonJobComparisonBusinessCase.php
+++ b/src/BusinessCase/Comparison/MarathonJobComparisonBusinessCase.php
@@ -56,7 +56,7 @@ class MarathonJobComparisonBusinessCase extends AbstractJobComparisionBusinessCa
                     continue;
                 }
 
-                if (!isset($remoteJob->container->docker->portMappings, $index)) {
+                if (!isset($remoteJob->container->docker->portMappings[$index])) {
                     continue;
                 }
 

--- a/src/Entity/Marathon/AppEntity/DockerPortMapping.php
+++ b/src/Entity/Marathon/AppEntity/DockerPortMapping.php
@@ -28,4 +28,25 @@ class DockerPortMapping
     {
         MarathonEntityUtils::setAllPossibleProperties($data, $this);
     }
+
+    public static function less(DockerPortMapping $left, DockerPortMapping $right)
+    {
+        if ($left->containerPort != $right->containerPort) {
+            return $left->containerPort - $right->containerPort;
+        }
+
+        if ($left->hostPort != $right->hostPort) {
+            return $left->hostPort - $right->hostPort;
+        }
+
+        if ($left->servicePort != $right->servicePort) {
+            return $left->servicePort - $right->servicePort;
+        }
+
+        if ($left->protocol != $right->protocol) {
+            return strcmp($left->protocol, $right->protocol);
+        }
+
+        return strcmp($left->name, $right->name);
+    }
 }

--- a/test/unit/BusinessCase/Comparison/MarathonJobComparisonBusinessCaseTest.php
+++ b/test/unit/BusinessCase/Comparison/MarathonJobComparisonBusinessCaseTest.php
@@ -250,6 +250,42 @@ class MarathonJobComparisonBusinessCaseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedDiff, $gotDiff, "Expected diff doesn't matched recieved diff");
     }
 
+    public function testJobDiffWithMissingRemotePortMappingSucceeds()
+    {
+        $localEntity = $this->getValidMarathonAppEntity('/main/id1');
+        $localEntity->container = new Container();
+        $localEntity->container->docker = new Docker();
+        $localEntity->container->docker->portMappings[] = new DockerPortMapping(["servicePort" => 0]);
+
+        $remoteEntity = $this->getValidMarathonAppEntity('/main/id1');
+        $remoteEntity->container = new Container();
+        $remoteEntity->container->docker = new Docker();
+        $remoteEntity->portDefinitions = new PortDefinition(["port" => 8080]);
+
+        $this->localRepository
+            ->getJob(Argument::exact($localEntity->getKey()))
+            ->willReturn($localEntity);
+
+        $this->remoteRepository
+            ->getJob(Argument::exact($remoteEntity->getKey()))
+            ->willReturn($remoteEntity);
+
+
+        $marathonJobCompare = new MarathonJobComparisonBusinessCase(
+            $this->localRepository->reveal(),
+            $this->remoteRepository->reveal(),
+            $this->diffCompare->reveal()
+        );
+
+        $gotDiff = $marathonJobCompare->getJobDiff('/main/id1');
+
+        $expectedDiff = [
+            'container' => null
+        ];
+        $this->assertEquals($expectedDiff, $gotDiff, "Expected diff doesn't matched recieved diff");
+    }
+
+
     public function testIsJobAvailableSuccess()
     {
         $this->localRepository


### PR DESCRIPTION
This fixes two bugs, namely the wrong syntax (`isset($array, $index)` vs `isset($array[$index])`) and a missing `array_values()` after updating the `portMappings`. It also adds sorting for the port mappings, in an attempt to make it more likely for the local and remote port mapping to be the "same".