### PR TITLE
Rename package "mikey179/vfsStream" to "mikey179/vfsstream" to prepare for composer 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,11 @@
   "description": "chronos console client - Manage your jobs like a git repository",
   "keywords": ["chronos", "api", "mesos"],
   "type": "project",
-  "authors": [
-    {
-      "name": "Marc Siebeneicher",
-      "email": "marc.siebeneicher@trivago.com",
-      "role": "developer"
-    }
-  ],
+  "authors": [{
+    "name": "Marc Siebeneicher",
+    "email": "marc.siebeneicher@trivago.com",
+    "role": "developer"
+  }],
   "license": "MIT",
   "require": {
     "php": ">=5.6.0",
@@ -30,10 +28,9 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~5.3",
-    "mikey179/vfsStream": "~1.5"
+    "mikey179/vfsstream": "~1.5"
   },
-  "autoload":
-  {
+  "autoload": {
     "psr-4": {
       "Chapi\\": ["src/"],
       "ChapiTest\\": ["test/"]
@@ -42,8 +39,7 @@
       "src/vendor/class.Diff.php"
     ]
   },
-  "autoload-dev":
-  {
+  "autoload-dev": {
     "psr-4": {
       "unit\\": ["test/unit/"]
     }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2df66dcd6d75c25bac6e2c8356de7069",
+    "content-hash": "2de13c9c12077f59e34bb9769c143597",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -1367,24 +1367,24 @@
             "time": "2015-06-14T21:17:01+00:00"
         },
         {
-            "name": "mikey179/vfsStream",
-            "version": "v1.6.5",
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mikey179/vfsStream.git",
-                "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145"
+                "url": "https://github.com/bovigo/vfsStream.git",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
-                "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.5"
+                "phpunit/phpunit": "^4.5|^5.0"
             },
             "type": "library",
             "extra": {
@@ -1410,7 +1410,7 @@
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
             "homepage": "http://vfs.bovigo.org/",
-            "time": "2017-08-01T08:02:14+00:00"
+            "time": "2019-10-30T15:31:00+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2575,5 +2575,6 @@
     "platform": {
         "php": ">=5.6.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
While executing "composer install" the following deprecation message was thrown:

Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.