### PR TITLE
Upgrade PHPUnit to PHPUnit 8 and fix unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 # PHPUnit
 /app/phpunit.xml
 /phpunit.xml
+test/.phpunit.result.cache
 
 # Build data
 /build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ dist: trusty
 sudo: false
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,22 @@
 {
   "name": "chapi/chapi-client",
   "description": "chronos console client - Manage your jobs like a git repository",
-  "keywords": ["chronos", "api", "mesos"],
+  "keywords": [
+    "chronos",
+    "api",
+    "mesos"
+  ],
   "type": "project",
-  "authors": [{
-    "name": "Marc Siebeneicher",
-    "email": "marc.siebeneicher@trivago.com",
-    "role": "developer"
-  }],
+  "authors": [
+    {
+      "name": "Marc Siebeneicher",
+      "email": "marc.siebeneicher@trivago.com",
+      "role": "developer"
+    }
+  ],
   "license": "MIT",
   "require": {
     "php": ">=5.6.0",
-
     "symfony/console": "~3.0",
     "symfony/dependency-injection": "~3.0",
     "symfony/yaml": "~3.0",
@@ -19,21 +24,23 @@
     "symfony/config": "~3.0",
     "symfony/monolog-bridge": "~3.0",
     "symfony/event-dispatcher": "~3.0",
-
     "doctrine/cache": "~1.6",
     "guzzlehttp/guzzle": "~6.2",
     "psr/log": "~1.0",
     "webmozart/glob": "~4.1"
-
   },
   "require-dev": {
-    "phpunit/phpunit": "~7.0",
+    "phpunit/phpunit": "~8.0",
     "mikey179/vfsstream": "~1.5"
   },
   "autoload": {
     "psr-4": {
-      "Chapi\\": ["src/"],
-      "ChapiTest\\": ["test/"]
+      "Chapi\\": [
+        "src/"
+      ],
+      "ChapiTest\\": [
+        "test/"
+      ]
     },
     "classmap": [
       "src/vendor/class.Diff.php"
@@ -41,12 +48,16 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "unit\\": ["test/unit/"]
+      "unit\\": [
+        "test/unit/"
+      ]
     }
   },
   "config": {
     "bin-dir": "bin"
   },
-  "bin": ["bin/chapi"],
+  "bin": [
+    "bin/chapi"
+  ],
   "minimum-stability": "stable"
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 
   },
   "require-dev": {
-    "phpunit/phpunit": "~6.0",
+    "phpunit/phpunit": "~7.0",
     "mikey179/vfsstream": "~1.5"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.3",
+    "phpunit/phpunit": "~6.0",
     "mikey179/vfsstream": "~1.5"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2de13c9c12077f59e34bb9769c143597",
+    "content-hash": "2d31cfa7b74cd30755c282f83d8efe2f",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -1952,40 +1952,41 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.8",
+            "version": "5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
+                "reference": "e648abfd8ffb1d54ad549b027b75e376e9055d02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/e648abfd8ffb1d54ad549b027b75e376e9055d02",
+                "reference": "e648abfd8ffb1d54ad549b027b75e376e9055d02",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^5.6 || ^7.0",
+                "php": "^7.0",
                 "phpunit/php-file-iterator": "^1.3",
                 "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "^1.0 || ^2.0"
+                "sebastian/environment": "^2.0",
+                "sebastian/version": "^2.0",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.1.4",
-                "phpunit/phpunit": "^5.7"
+                "ext-xdebug": "^2.5",
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.5.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.2.x-dev"
                 }
             },
             "autoload": {
@@ -2011,7 +2012,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-02T07:44:40+00:00"
+            "time": "2017-04-20T10:00:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2201,16 +2202,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.27",
+            "version": "6.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
+                "reference": "47ee3fa1bca5c50f1d25105201eb20df777bd7b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/47ee3fa1bca5c50f1d25105201eb20df777bd7b6",
+                "reference": "47ee3fa1bca5c50f1d25105201eb20df777bd7b6",
                 "shasum": ""
             },
             "require": {
@@ -2219,33 +2220,33 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
+                "myclabs/deep-copy": "^1.3",
+                "php": "^7.0",
                 "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.4",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-code-coverage": "^5.0",
+                "phpunit/php-file-iterator": "^1.4",
+                "phpunit/php-text-template": "^1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "^1.4.3",
-                "sebastian/environment": "^1.3.4 || ^2.0",
-                "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "^1.1",
-                "sebastian/object-enumerator": "~2.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "^1.0.6|^2.0.1",
-                "symfony/yaml": "~2.1|~3.0|~4.0"
+                "phpunit/phpunit-mock-objects": "^4.0",
+                "sebastian/comparator": "^1.2.4 || ^2.0",
+                "sebastian/diff": "^1.2",
+                "sebastian/environment": "^2.0",
+                "sebastian/exporter": "^2.0 || ^3.0",
+                "sebastian/global-state": "^1.1 || ^2.0",
+                "sebastian/object-enumerator": "^2.0 || ^3.0",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -2253,7 +2254,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.7.x-dev"
+                    "dev-master": "6.0.x-dev"
                 }
             },
             "autoload": {
@@ -2279,33 +2280,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-01T05:50:59+00:00"
+            "time": "2017-03-02T15:24:03+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.4",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
+                "reference": "3819745c44f3aff9518fd655f320c4535d541af7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3819745c44f3aff9518fd655f320c4535d541af7",
+                "reference": "3819745c44f3aff9518fd655f320c4535d541af7",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
+                "php": "^7.0",
                 "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
+                "sebastian/exporter": "^2.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<5.4.0"
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.4"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -2313,7 +2314,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -2339,7 +2340,7 @@
                 "xunit"
             ],
             "abandoned": true,
-            "time": "2017-06-30T09:13:00+00:00"
+            "time": "2017-02-02T10:36:38+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2621,23 +2622,23 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -2645,7 +2646,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2668,7 +2669,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -2853,6 +2854,46 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2019-06-13T22:48:21+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -1585,32 +1585,34 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
+                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -1630,12 +1632,26 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-29T17:27:14+00:00"
         },
         {
             "name": "mikey179/vfsstream",
@@ -2185,16 +2201,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.21",
+            "version": "5.7.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3b91adfb64264ddec5a2dee9851f354aa66327db"
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3b91adfb64264ddec5a2dee9851f354aa66327db",
-                "reference": "3b91adfb64264ddec5a2dee9851f354aa66327db",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
                 "shasum": ""
             },
             "require": {
@@ -2218,8 +2234,8 @@
                 "sebastian/global-state": "^1.1",
                 "sebastian/object-enumerator": "~2.0",
                 "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0.3|~2.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "sebastian/version": "^1.0.6|^2.0.1",
+                "symfony/yaml": "~2.1|~3.0|~4.0"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "3.0.2"
@@ -2263,7 +2279,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-06-21T08:11:54+00:00"
+            "time": "2018-02-01T05:50:59+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5262d69cabb03c0970debc9339922ad3",
+    "content-hash": "88ca0923d427942b223bab94da7e087e",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -1701,37 +1701,43 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.6.1",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "DeepCopy\\": "src/DeepCopy/"
-                }
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
                 "clone",
                 "copy",
@@ -1739,26 +1745,26 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-04-12T18:52:22+00:00"
+            "time": "2020-01-17T21:11:47+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
+                "phar-io/version": "^2.0",
                 "php": "^5.6 || ^7.0"
             },
             "type": "library",
@@ -1794,20 +1800,20 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2018-07-08T19:23:20+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
                 "shasum": ""
             },
             "require": {
@@ -1841,7 +1847,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2018-07-08T19:19:57+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1991,38 +1997,38 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1|^2.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpspec/phpspec": "^2.5 || ^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2050,44 +2056,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.5",
+            "version": "7.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4cab20a326d14de7575a8e235c70d879b569a57a"
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4cab20a326d14de7575a8e235c70d879b569a57a",
-                "reference": "4cab20a326d14de7575a8e235c70d879b569a57a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f1884187926fbb755a9aaf0b3836ad3165b478bf",
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "php": "^7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
+                "phpunit/php-token-stream": "^3.1.1",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^4.2.2",
                 "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -2113,29 +2119,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-05-28T11:49:20+00:00"
+            "time": "2019-11-20T13:55:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -2150,7 +2159,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -2160,7 +2169,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -2303,49 +2312,52 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.1.4",
+            "version": "8.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6d51299e307dc510149e0b7cd1931dd11770e1cb"
+                "reference": "63dda3b212a0025d380a745f91bdb4d8c985adb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6d51299e307dc510149e0b7cd1931dd11770e1cb",
-                "reference": "6d51299e307dc510149e0b7cd1931dd11770e1cb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/63dda3b212a0025d380a745f91bdb4d8c985adb7",
+                "reference": "63dda3b212a0025d380a745f91bdb4d8c985adb7",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.2.0",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.1",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.1",
-                "phpunit/php-file-iterator": "^1.4.3",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.2",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^7.0.7",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.0",
-                "phpunit/phpunit-mock-objects": "^6.1.1",
-                "sebastian/comparator": "^2.1 || ^3.0",
-                "sebastian/diff": "^3.0",
-                "sebastian/environment": "^3.1",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/exporter": "^3.1.1",
+                "sebastian/global-state": "^3.0.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
                 "sebastian/version": "^2.0.1"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0"
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -2353,7 +2365,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.1-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
@@ -2379,64 +2391,17 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-18T13:41:53+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "6.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "f9756fd4f43f014cb2dca98deeaaa8ce5500a36e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/f9756fd4f43f014cb2dca98deeaaa8ce5500a36e",
-                "reference": "f9756fd4f43f014cb2dca98deeaaa8ce5500a36e",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.1",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "abandoned": true,
-            "time": "2018-05-29T13:54:20+00:00"
+            "time": "2020-05-22T13:51:52+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2485,30 +2450,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.3",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2545,7 +2510,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01T13:46:46+00:00"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -2605,28 +2570,31 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2651,7 +2619,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2019-11-20T08:46:58+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -2722,23 +2690,26 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -2746,7 +2717,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2769,7 +2740,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "time": "2019-02-01T05:30:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -2918,25 +2889,25 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2956,7 +2927,53 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2019-07-02T08:10:15+00:00"
         },
         {
             "name": "sebastian/version",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d31cfa7b74cd30755c282f83d8efe2f",
+    "content-hash": "5262d69cabb03c0970debc9339922ad3",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -1742,6 +1742,108 @@
             "time": "2017-04-12T18:52:22+00:00"
         },
         {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "1.0",
             "source": {
@@ -1952,41 +2054,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.0",
+            "version": "6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "e648abfd8ffb1d54ad549b027b75e376e9055d02"
+                "reference": "4cab20a326d14de7575a8e235c70d879b569a57a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/e648abfd8ffb1d54ad549b027b75e376e9055d02",
-                "reference": "e648abfd8ffb1d54ad549b027b75e376e9055d02",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4cab20a326d14de7575a8e235c70d879b569a57a",
+                "reference": "4cab20a326d14de7575a8e235c70d879b569a57a",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^2.0",
-                "sebastian/version": "^2.0",
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.1",
+                "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.5",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.3"
+                "ext-xdebug": "^2.6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.2.x-dev"
+                    "dev-master": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2001,7 +2102,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -2012,20 +2113,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-20T10:00:57+00:00"
+            "time": "2018-05-28T11:49:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -2059,7 +2160,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -2104,28 +2205,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -2140,7 +2241,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -2149,33 +2250,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.11",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -2198,20 +2299,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2019-09-17T06:23:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.0.8",
+            "version": "7.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "47ee3fa1bca5c50f1d25105201eb20df777bd7b6"
+                "reference": "6d51299e307dc510149e0b7cd1931dd11770e1cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/47ee3fa1bca5c50f1d25105201eb20df777bd7b6",
-                "reference": "47ee3fa1bca5c50f1d25105201eb20df777bd7b6",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6d51299e307dc510149e0b7cd1931dd11770e1cb",
+                "reference": "6d51299e307dc510149e0b7cd1931dd11770e1cb",
                 "shasum": ""
             },
             "require": {
@@ -2220,33 +2321,31 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.3",
-                "php": "^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^5.0",
-                "phpunit/php-file-iterator": "^1.4",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^4.0",
-                "sebastian/comparator": "^1.2.4 || ^2.0",
-                "sebastian/diff": "^1.2",
-                "sebastian/environment": "^2.0",
-                "sebastian/exporter": "^2.0 || ^3.0",
-                "sebastian/global-state": "^1.1 || ^2.0",
-                "sebastian/object-enumerator": "^2.0 || ^3.0",
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.1",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^6.0.1",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.0",
+                "phpunit/phpunit-mock-objects": "^6.1.1",
+                "sebastian/comparator": "^2.1 || ^3.0",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
                 "sebastian/resource-operations": "^1.0",
-                "sebastian/version": "^2.0"
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
+                "sebastian/version": "^2.0.1"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "phpunit/php-invoker": "^2.0"
             },
             "bin": [
                 "phpunit"
@@ -2254,7 +2353,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0.x-dev"
+                    "dev-master": "7.1-dev"
                 }
             },
             "autoload": {
@@ -2280,33 +2379,30 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-03-02T15:24:03+00:00"
+            "time": "2018-04-18T13:41:53+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "4.0.0",
+            "version": "6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "3819745c44f3aff9518fd655f320c4535d541af7"
+                "reference": "f9756fd4f43f014cb2dca98deeaaa8ce5500a36e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3819745c44f3aff9518fd655f320c4535d541af7",
-                "reference": "3819745c44f3aff9518fd655f320c4535d541af7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/f9756fd4f43f014cb2dca98deeaaa8ce5500a36e",
+                "reference": "f9756fd4f43f014cb2dca98deeaaa8ce5500a36e",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^2.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<6.0"
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.1",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -2314,7 +2410,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -2329,7 +2425,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -2340,7 +2436,7 @@
                 "xunit"
             ],
             "abandoned": true,
-            "time": "2017-02-02T10:36:38+00:00"
+            "time": "2018-05-29T13:54:20+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2389,30 +2485,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^7.0",
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -2443,38 +2539,39 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2499,34 +2596,37 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -2551,34 +2651,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "2.0.0",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -2592,6 +2692,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -2600,16 +2704,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -2618,7 +2718,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+00:00"
+            "time": "2019-09-14T09:02:43+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -2673,29 +2773,30 @@
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2715,32 +2816,77 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18T15:18:39+00:00"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "2.0.0",
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2768,7 +2914,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -8,19 +8,17 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          forceCoversAnnotation="false"
-         mapTestClassNameToCoveredClassName="false"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         verbose="true"
-         coverage-clover="clover.xml">
+         verbose="true">
 
     <logging>
-        <log type="coverage-html" target="../build/clover-html" charset="UTF-8" yui="true" highlight="true" lowUpperBound="35" highLowerBound="70"/>
+        <log type="coverage-html" target="../build/clover-html" lowUpperBound="35" highLowerBound="70"/>
         <log type="coverage-clover" target="../build/clover.xml"/>
-        <log type="junit" target="../build/junit.xml" logIncompleteSkipped="false"/>
+        <log type="junit" target="../build/junit.xml" />
         <log type="testdox-html" target="../build/testdox.html"/>
         <log type="testdox-text" target="../build/testdox.txt"/>
         <!--<log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>-->

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -9,13 +9,11 @@
          convertWarningsToExceptions="true"
          forceCoversAnnotation="false"
          mapTestClassNameToCoveredClassName="false"
-         printerClass="PHPUnit_TextUI_ResultPrinter"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
          verbose="true"
          coverage-clover="clover.xml">
 

--- a/test/phpunit_quicktest.xml
+++ b/test/phpunit_quicktest.xml
@@ -8,14 +8,12 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          forceCoversAnnotation="false"
-         mapTestClassNameToCoveredClassName="false"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         verbose="true"
-         coverage-clover="clover.xml">
+         verbose="true">
 
     <testsuites>
         <testsuite name="Unit-Tests">

--- a/test/unit/BusinessCase/Comparison/ChronosComparisonBusinessCaseTest.php
+++ b/test/unit/BusinessCase/Comparison/ChronosComparisonBusinessCaseTest.php
@@ -32,7 +32,7 @@ class ChronosComparisonBusinessCaseTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $logger;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->jobRepositoryLocalChronos = $this->prophesize('Chapi\Service\JobRepository\JobRepositoryInterface');
         $this->jobRepositoryChronos = $this->prophesize('Chapi\Service\JobRepository\JobRepositoryInterface');

--- a/test/unit/BusinessCase/Comparison/ChronosComparisonBusinessCaseTest.php
+++ b/test/unit/BusinessCase/Comparison/ChronosComparisonBusinessCaseTest.php
@@ -13,7 +13,7 @@ use Chapi\BusinessCase\Comparison\ChronosJobComparisonBusinessCase;
 use Chapi\Component\DatePeriod\DatePeriodFactory;
 use ChapiTest\src\TestTraits\JobEntityTrait;
 
-class ChronosComparisonBusinessCaseTest extends \PHPUnit_Framework_TestCase
+class ChronosComparisonBusinessCaseTest extends \PHPUnit\Framework\TestCase
 {
     use JobEntityTrait;
 
@@ -270,7 +270,7 @@ class ChronosComparisonBusinessCaseTest extends \PHPUnit_Framework_TestCase
             $localJobUpdates
         );
     }
-    
+
     public function testGetLocalUpdatesForConstraintsDifference()
     {
         $jobEntityA1 = $this->getValidScheduledJobEntity('JobA');
@@ -305,7 +305,7 @@ class ChronosComparisonBusinessCaseTest extends \PHPUnit_Framework_TestCase
         );
 
         $localJobUpdates = $jobComparisonBusinessCase->getLocalJobUpdates();
-        
+
         $this->assertEquals(
             ['JobA'],
             $localJobUpdates
@@ -335,11 +335,11 @@ class ChronosComparisonBusinessCaseTest extends \PHPUnit_Framework_TestCase
             $localJobUpdates
         );
     }
-    
+
     private function setupContainerDifference($sProperty, $mValue)
     {
         $this->setUp();
-        
+
         $jobEntityA1 = $this->getValidContainerJobEntity('JobA');
         $jobEntityA2 = $this->getValidContainerJobEntity('JobA');
 

--- a/test/unit/BusinessCase/Comparison/CompositeJobComparisonBusinessCaseTest.php
+++ b/test/unit/BusinessCase/Comparison/CompositeJobComparisonBusinessCaseTest.php
@@ -12,7 +12,7 @@ namespace ChapiTest\unit\BusinessCase\Comparison;
 use Chapi\BusinessCase\Comparison\CompositeJobComparisonBusinessCase;
 use Prophecy\Argument;
 
-class CompositeJobComparisonBusinessCaseTest extends \PHPUnit_Framework_TestCase
+class CompositeJobComparisonBusinessCaseTest extends \PHPUnit\Framework\TestCase
 {
 
     /** @var  \Prophecy\Prophecy\ObjectProphecy */

--- a/test/unit/BusinessCase/Comparison/CompositeJobComparisonBusinessCaseTest.php
+++ b/test/unit/BusinessCase/Comparison/CompositeJobComparisonBusinessCaseTest.php
@@ -21,7 +21,7 @@ class CompositeJobComparisonBusinessCaseTest extends \PHPUnit\Framework\TestCase
     /** @var  \Prophecy\Prophecy\ObjectProphecy */
     private $chronosCase;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->marathonCase = $this->prophesize('Chapi\BusinessCase\Comparison\JobComparisonInterface');
         $this->chronosCase = $this->prophesize('Chapi\BusinessCase\Comparison\JobComparisonInterface');

--- a/test/unit/BusinessCase/Comparison/MarathonJobComparisonBusinessCaseTest.php
+++ b/test/unit/BusinessCase/Comparison/MarathonJobComparisonBusinessCaseTest.php
@@ -20,7 +20,7 @@ use ChapiTest\src\TestTraits\AppEntityTrait;
 use Prophecy\Argument;
 use Symfony\Component\Console\Tests\Input\ArgvInputTest;
 
-class MarathonJobComparisonBusinessCaseTest extends \PHPUnit_Framework_TestCase
+class MarathonJobComparisonBusinessCaseTest extends \PHPUnit\Framework\TestCase
 {
     use AppEntityTrait;
 

--- a/test/unit/BusinessCase/Comparison/MarathonJobComparisonBusinessCaseTest.php
+++ b/test/unit/BusinessCase/Comparison/MarathonJobComparisonBusinessCaseTest.php
@@ -33,7 +33,7 @@ class MarathonJobComparisonBusinessCaseTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $diffCompare;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->remoteRepository = $this->prophesize('Chapi\Service\JobRepository\JobRepositoryInterface');
         $this->localRepository = $this->prophesize('Chapi\Service\JobRepository\JobRepositoryInterface');

--- a/test/unit/BusinessCase/JobManagement/ChronosStoreJobBusinessCaseTest.php
+++ b/test/unit/BusinessCase/JobManagement/ChronosStoreJobBusinessCaseTest.php
@@ -503,11 +503,10 @@ class ChronosStoreJobBusinessCaseTest extends \PHPUnit\Framework\TestCase
         $this->logger->notice(Argument::type('string'))->shouldBeCalled();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testStoreJobsToLocalRepositoryFailureBecauseJobExists()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $jobEntityA1 = $this->getValidScheduledJobEntity('JobA');
         $jobEntityA2 = clone $jobEntityA1;
         $jobEntityA2->disabled = true;

--- a/test/unit/BusinessCase/JobManagement/ChronosStoreJobBusinessCaseTest.php
+++ b/test/unit/BusinessCase/JobManagement/ChronosStoreJobBusinessCaseTest.php
@@ -39,7 +39,7 @@ class ChronosStoreJobBusinessCaseTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $logger;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->jobIndexService = $this->prophesize('Chapi\Service\JobIndex\JobIndexServiceInterface');
         $this->jobRepositoryRemote = $this->prophesize('Chapi\Service\JobRepository\JobRepositoryInterface');

--- a/test/unit/BusinessCase/JobManagement/ChronosStoreJobBusinessCaseTest.php
+++ b/test/unit/BusinessCase/JobManagement/ChronosStoreJobBusinessCaseTest.php
@@ -17,7 +17,7 @@ use Chapi\Service\JobDependencies\JobDependencyServiceInterface;
 use ChapiTest\src\TestTraits\JobEntityTrait;
 use Prophecy\Argument;
 
-class ChronosStoreJobBusinessCaseTest extends \PHPUnit_Framework_TestCase
+class ChronosStoreJobBusinessCaseTest extends \PHPUnit\Framework\TestCase
 {
     use JobEntityTrait;
 

--- a/test/unit/BusinessCase/JobManagement/MarathonStoreJobBusinessCaseTest.php
+++ b/test/unit/BusinessCase/JobManagement/MarathonStoreJobBusinessCaseTest.php
@@ -34,7 +34,7 @@ class MarathonStoreJobBusinessCaseTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $logger;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->jobIndexService = $this->prophesize('Chapi\Service\JobIndex\JobIndexServiceInterface');
         $this->jobRepositoryRemote = $this->prophesize('Chapi\Service\JobRepository\JobRepositoryInterface');

--- a/test/unit/BusinessCase/JobManagement/MarathonStoreJobBusinessCaseTest.php
+++ b/test/unit/BusinessCase/JobManagement/MarathonStoreJobBusinessCaseTest.php
@@ -15,7 +15,7 @@ use Exception;
 use InvalidArgumentException;
 use Prophecy\Argument;
 
-class MarathonStoreJobBusinessCaseTest extends \PHPUnit_Framework_TestCase
+class MarathonStoreJobBusinessCaseTest extends \PHPUnit\Framework\TestCase
 {
     use AppEntityTrait;
 

--- a/test/unit/BusinessCase/JobManagement/MarathonStoreJobBusinessCaseTest.php
+++ b/test/unit/BusinessCase/JobManagement/MarathonStoreJobBusinessCaseTest.php
@@ -255,11 +255,10 @@ class MarathonStoreJobBusinessCaseTest extends \PHPUnit\Framework\TestCase
         $marathonStore->storeJobsToLocalRepository([], true);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testStoreJobsToLocalRepositoryWithUpdateFailureWithoutForce()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $remoteJobs = $this->createAppCollection(["/main/id1", "/main/id2"]);
         $localJobs = $this->createAppCollection(["/main/id1", "/main/id2"]);
 

--- a/test/unit/Command/AbstractCommandTest.php
+++ b/test/unit/Command/AbstractCommandTest.php
@@ -14,7 +14,7 @@ use ChapiTest\src\TestTraits\CommandTestTrait;
 use org\bovigo\vfs\vfsStream;
 use Prophecy\Argument;
 
-class AbstractCommandTest extends \PHPUnit_Framework_TestCase
+class AbstractCommandTest extends \PHPUnit\Framework\TestCase
 {
     use CommandTestTrait;
 

--- a/test/unit/Command/AbstractCommandTest.php
+++ b/test/unit/Command/AbstractCommandTest.php
@@ -21,7 +21,7 @@ class AbstractCommandTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $consoleHandler;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->setUpCommandDependencies();
 

--- a/test/unit/Command/AbstractCommandTest.php
+++ b/test/unit/Command/AbstractCommandTest.php
@@ -42,8 +42,8 @@ class AbstractCommandTest extends \PHPUnit\Framework\TestCase
         $command = new AbstractCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertContains('.chapi', $command->getHomeDirPub());
-        $this->assertContains($homeDir, $command->getHomeDirPub());
+        $this->assertStringContainsString('.chapi', $command->getHomeDirPub());
+        $this->assertStringContainsString($homeDir, $command->getHomeDirPub());
         $this->assertTrue(is_dir($command->getHomeDirPub()));
     }
 
@@ -52,7 +52,7 @@ class AbstractCommandTest extends \PHPUnit\Framework\TestCase
         $command = new AbstractCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertContains('cache', $command->getCacheDir());
+        $this->assertStringContainsString('cache', $command->getCacheDir());
         $this->assertTrue(is_dir($command->getCacheDir()));
     }
 

--- a/test/unit/Command/AddCommandTest.php
+++ b/test/unit/Command/AddCommandTest.php
@@ -15,7 +15,7 @@ use Chapi\Service\JobIndex\JobIndexServiceInterface;
 use ChapiTest\src\TestTraits\CommandTestTrait;
 use Prophecy\Argument;
 
-class AddCommandTest extends \PHPUnit_Framework_TestCase
+class AddCommandTest extends \PHPUnit\Framework\TestCase
 {
     use CommandTestTrait;
 

--- a/test/unit/Command/AddCommandTest.php
+++ b/test/unit/Command/AddCommandTest.php
@@ -21,7 +21,7 @@ class AddCommandTest extends \PHPUnit\Framework\TestCase
 
     private $jobIndexServiceInterface;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->jobIndexServiceInterface = $this->prophesize('Chapi\Service\JobIndex\JobIndexServiceInterface');
     }

--- a/test/unit/Command/ConfigureCommandTest.php
+++ b/test/unit/Command/ConfigureCommandTest.php
@@ -25,7 +25,7 @@ class ConfigureCommandTest extends \PHPUnit\Framework\TestCase
      */
     private $tempTestDir = '';
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->setUpCommandDependencies();
 
@@ -41,7 +41,7 @@ class ConfigureCommandTest extends \PHPUnit\Framework\TestCase
         ConfigureCommandDummy::$homeDirDummy = $this->tempTestDir;
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         if (file_exists($this->tempTestDir . DIRECTORY_SEPARATOR . '.chapiconfig')) {
             unlink($this->tempTestDir . DIRECTORY_SEPARATOR . '.chapiconfig');

--- a/test/unit/Command/ConfigureCommandTest.php
+++ b/test/unit/Command/ConfigureCommandTest.php
@@ -13,7 +13,7 @@ namespace unit\Command;
 use ChapiTest\src\TestTraits\CommandTestTrait;
 use Prophecy\Argument;
 
-class ConfigureCommandTest extends \PHPUnit_Framework_TestCase
+class ConfigureCommandTest extends \PHPUnit\Framework\TestCase
 {
     use CommandTestTrait;
 

--- a/test/unit/Command/InfoCommandTest.php
+++ b/test/unit/Command/InfoCommandTest.php
@@ -15,7 +15,7 @@ use ChapiTest\src\TestTraits\CommandTestTrait;
 use ChapiTest\src\TestTraits\JobEntityTrait;
 use Prophecy\Argument;
 
-class InfoCommandTest extends \PHPUnit_Framework_TestCase
+class InfoCommandTest extends \PHPUnit\Framework\TestCase
 {
     use CommandTestTrait;
     use JobEntityTrait;

--- a/test/unit/Command/InfoCommandTest.php
+++ b/test/unit/Command/InfoCommandTest.php
@@ -23,7 +23,7 @@ class InfoCommandTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $jobRepositoryChronos;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->setUpCommandDependencies();
 

--- a/test/unit/Command/ListCommandTest.php
+++ b/test/unit/Command/ListCommandTest.php
@@ -16,7 +16,7 @@ use ChapiTest\src\TestTraits\CommandTestTrait;
 use ChapiTest\src\TestTraits\JobEntityTrait;
 use Prophecy\Argument;
 
-class ListCommandTest extends \PHPUnit_Framework_TestCase
+class ListCommandTest extends \PHPUnit\Framework\TestCase
 {
     use CommandTestTrait;
     use JobEntityTrait;

--- a/test/unit/Command/ListCommandTest.php
+++ b/test/unit/Command/ListCommandTest.php
@@ -28,7 +28,7 @@ class ListCommandTest extends \PHPUnit\Framework\TestCase
     /** @var  \Prophecy\Prophecy\ObjectProphecy */
     private $jobRepositoryMarathon;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->setUpCommandDependencies();
 

--- a/test/unit/Command/ResetCommandTest.php
+++ b/test/unit/Command/ResetCommandTest.php
@@ -20,7 +20,7 @@ class ResetCommandTest extends \PHPUnit\Framework\TestCase
 
     private $jobIndexServiceInterface;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->jobIndexServiceInterface = $this->prophesize('Chapi\Service\JobIndex\JobIndexServiceInterface');
     }

--- a/test/unit/Command/ResetCommandTest.php
+++ b/test/unit/Command/ResetCommandTest.php
@@ -14,7 +14,7 @@ use Chapi\Service\JobIndex\JobIndexServiceInterface;
 use ChapiTest\src\TestTraits\CommandTestTrait;
 use Prophecy\Argument;
 
-class ResetCommandTest extends \PHPUnit_Framework_TestCase
+class ResetCommandTest extends \PHPUnit\Framework\TestCase
 {
     use CommandTestTrait;
 

--- a/test/unit/Command/SchedulingViewCommandTest.php
+++ b/test/unit/Command/SchedulingViewCommandTest.php
@@ -20,7 +20,7 @@ use ChapiTest\src\TestTraits\JobEntityTrait;
 use Prophecy\Argument;
 use ChapiTest\src\TestTraits\JobStatsEntityTrait;
 
-class SchedulingViewCommandTest extends \PHPUnit_Framework_TestCase
+class SchedulingViewCommandTest extends \PHPUnit\Framework\TestCase
 {
     use CommandTestTrait;
     use JobStatsEntityTrait;

--- a/test/unit/Command/SchedulingViewCommandTest.php
+++ b/test/unit/Command/SchedulingViewCommandTest.php
@@ -38,7 +38,7 @@ class SchedulingViewCommandTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $datePeriodFactory;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->setUpCommandDependencies();
 

--- a/test/unit/Command/ValidationCommandTest.php
+++ b/test/unit/Command/ValidationCommandTest.php
@@ -17,7 +17,7 @@ use ChapiTest\src\TestTraits\CommandTestTrait;
 use ChapiTest\src\TestTraits\JobEntityTrait;
 use Prophecy\Argument;
 
-class ValidationCommandTest extends \PHPUnit_Framework_TestCase
+class ValidationCommandTest extends \PHPUnit\Framework\TestCase
 {
     use CommandTestTrait;
     use JobEntityTrait;

--- a/test/unit/Command/ValidationCommandTest.php
+++ b/test/unit/Command/ValidationCommandTest.php
@@ -28,7 +28,7 @@ class ValidationCommandTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $jobRepositoryLocal;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->setUpCommandDependencies();
 

--- a/test/unit/Component/Cache/DoctrineCacheTest.php
+++ b/test/unit/Component/Cache/DoctrineCacheTest.php
@@ -13,7 +13,7 @@ namespace unit\Component\Cache;
 use Chapi\Component\Cache\DoctrineCache;
 use Prophecy\Argument;
 
-class DoctrineCacheTest extends \PHPUnit_Framework_TestCase
+class DoctrineCacheTest extends \PHPUnit\Framework\TestCase
 {
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $cache;

--- a/test/unit/Component/Cache/DoctrineCacheTest.php
+++ b/test/unit/Component/Cache/DoctrineCacheTest.php
@@ -21,7 +21,7 @@ class DoctrineCacheTest extends \PHPUnit\Framework\TestCase
     /**
      * set up default mocks
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->cache = $this->prophesize('Doctrine\Common\Cache\Cache');
     }

--- a/test/unit/Component/Command/CommandUtilsTest.php
+++ b/test/unit/Component/Command/CommandUtilsTest.php
@@ -12,7 +12,7 @@ namespace unit\Component\Command;
 use Chapi\Component\Command\CommandUtils;
 use org\bovigo\vfs\vfsStream;
 
-class CommandUtilsTest extends \PHPUnit_Framework_TestCase
+class CommandUtilsTest extends \PHPUnit\Framework\TestCase
 {
 
 

--- a/test/unit/Component/Command/JobUtilsTest.php
+++ b/test/unit/Component/Command/JobUtilsTest.php
@@ -48,11 +48,10 @@ class JobUtilsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($jobs, JobUtils::getJobNames($input->reveal(), $command->reveal()));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGetJobNamesFailure()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $command = $this->prophesize('Symfony\Component\Console\Command\Command');
         $command->getName()->willReturn('CommandName')->shouldBeCalledTimes(2);
 

--- a/test/unit/Component/Command/JobUtilsTest.php
+++ b/test/unit/Component/Command/JobUtilsTest.php
@@ -14,7 +14,7 @@ use Chapi\Component\Command\JobUtilsInterface;
 use Prophecy\Argument;
 use Symfony\Component\Console\Input\InputArgument;
 
-class JobUtilsTest extends \PHPUnit_Framework_TestCase
+class JobUtilsTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testConfigureJobNamesArgument()

--- a/test/unit/Component/Config/ChapiConfigTest.php
+++ b/test/unit/Component/Config/ChapiConfigTest.php
@@ -150,6 +150,6 @@ class ChapiConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('update_user', $profileConfig['parameters']['chronos_http_username']);
         $this->assertEquals('new_user', $profileConfig['parameters']['marathon_http_username']);
 
-        $this->assertArraySubset(['*-stage', 'new-entry'], $profileConfig['ignore']);
+        $this->assertEquals(['*-stage', 'new-entry'], $profileConfig['ignore']);
     }
 }

--- a/test/unit/Component/Config/ChapiConfigTest.php
+++ b/test/unit/Component/Config/ChapiConfigTest.php
@@ -15,7 +15,7 @@ use org\bovigo\vfs\vfsStreamDirectory;
 use Symfony\Component\Yaml\Dumper;
 use Symfony\Component\Yaml\Parser;
 
-class ChapiConfigTest extends \PHPUnit_Framework_TestCase
+class ChapiConfigTest extends \PHPUnit\Framework\TestCase
 {
     /** @var  vfsStreamDirectory */
     private $vfsRoot;

--- a/test/unit/Component/Config/ChapiConfigTest.php
+++ b/test/unit/Component/Config/ChapiConfigTest.php
@@ -41,7 +41,7 @@ class ChapiConfigTest extends \PHPUnit\Framework\TestCase
      */
     private $testConfigA;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new Parser();
         $this->dumper = new Dumper();

--- a/test/unit/Component/DatePeriod/DatePeriodFactoryTest.php
+++ b/test/unit/Component/DatePeriod/DatePeriodFactoryTest.php
@@ -33,11 +33,10 @@ class DatePeriodFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('PT1M', $iso8601Entity->interval);
     }
 
-    /**
-     * @expectedException \Chapi\Exception\DatePeriodException
-     */
     public function testParseIso8601StringFailure()
     {
+        $this->expectException(\Chapi\Exception\DatePeriodException::class);
+
         $datePeriodFactory = new DatePeriodFactory();
 
         $this->assertNull(
@@ -78,11 +77,10 @@ class DatePeriodFactoryTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @expectedException \Chapi\Exception\DatePeriodException
-     */
     public function testCreateDatePeriodFailure()
     {
+        $this->expectException(\Chapi\Exception\DatePeriodException::class);
+
         $datePeriodFactory = new DatePeriodFactory();
 
         $this->assertNull(

--- a/test/unit/Component/DatePeriod/DatePeriodFactoryTest.php
+++ b/test/unit/Component/DatePeriod/DatePeriodFactoryTest.php
@@ -11,7 +11,7 @@ namespace unit\Component\DatePeriod;
 
 use Chapi\Component\DatePeriod\DatePeriodFactory;
 
-class DatePeriodFactoryTest extends \PHPUnit_Framework_TestCase
+class DatePeriodFactoryTest extends \PHPUnit\Framework\TestCase
 {
     public function testParseIso8601StringSuccess()
     {

--- a/test/unit/Component/DependencyInjection/ChapiConfigLoaderTest.php
+++ b/test/unit/Component/DependencyInjection/ChapiConfigLoaderTest.php
@@ -19,7 +19,7 @@ class ChapiConfigLoaderTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $config;
 
-    public function setUp()
+    protected function setUp(): void
     {
         // Symfony\Component\DependencyInjection\ContainerInterface
         $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerBuilder');

--- a/test/unit/Component/DependencyInjection/ChapiConfigLoaderTest.php
+++ b/test/unit/Component/DependencyInjection/ChapiConfigLoaderTest.php
@@ -53,11 +53,10 @@ class ChapiConfigLoaderTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($chapiConfigLoader->loadProfileParameters());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLoadProfileParametersFailure()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->config->getProfileConfig()->willReturn([
             'parameters' => 'not_valid'
         ]);

--- a/test/unit/Component/DependencyInjection/ChapiConfigLoaderTest.php
+++ b/test/unit/Component/DependencyInjection/ChapiConfigLoaderTest.php
@@ -11,7 +11,7 @@ namespace unit\Component\Config;
 
 use Chapi\Component\DependencyInjection\Loader\ChapiConfigLoader;
 
-class ChapiConfigLoaderTest extends \PHPUnit_Framework_TestCase
+class ChapiConfigLoaderTest extends \PHPUnit\Framework\TestCase
 {
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $container;

--- a/test/unit/Component/Http/HttpGuzzlClientTest.php
+++ b/test/unit/Component/Http/HttpGuzzlClientTest.php
@@ -73,11 +73,10 @@ class HttpGuzzlClientTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('Chapi\Component\Http\HttpClientResponseInterface', $response);
     }
 
-    /**
-     * @expectedException \Chapi\Exception\HttpConnectionException
-     */
     public function testGetFailure()
     {
+        $this->expectException(\Chapi\Exception\HttpConnectionException::class);
+
         $url = '/url/for/test';
 
         $authEntity = new AuthEntity("", "");

--- a/test/unit/Component/Http/HttpGuzzlClientTest.php
+++ b/test/unit/Component/Http/HttpGuzzlClientTest.php
@@ -14,7 +14,7 @@ use Chapi\Component\Http\HttpGuzzleClient;
 use Chapi\Entity\Http\AuthEntity;
 use Prophecy\Argument;
 
-class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
+class HttpGuzzlClientTest extends \PHPUnit\Framework\TestCase
 {
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $guzzleClient;

--- a/test/unit/Component/Http/HttpGuzzlClientTest.php
+++ b/test/unit/Component/Http/HttpGuzzlClientTest.php
@@ -22,7 +22,7 @@ class HttpGuzzlClientTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $guzzleResponse;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->guzzleClient = $this->prophesize('GuzzleHttp\ClientInterface');
         $this->guzzleResponse = $this->prophesize('Psr\Http\Message\ResponseInterface');

--- a/test/unit/Component/Http/HttpGuzzleResponseTest.php
+++ b/test/unit/Component/Http/HttpGuzzleResponseTest.php
@@ -10,7 +10,7 @@ namespace unit\Component\Http;
 
 use Chapi\Component\Http\HttpGuzzleResponse;
 
-class HttpGuzzleResponseTest extends \PHPUnit_Framework_TestCase
+class HttpGuzzleResponseTest extends \PHPUnit\Framework\TestCase
 {
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $responseInterface;

--- a/test/unit/Component/Http/HttpGuzzleResponseTest.php
+++ b/test/unit/Component/Http/HttpGuzzleResponseTest.php
@@ -77,7 +77,7 @@ class HttpGuzzleResponseTest extends \PHPUnit\Framework\TestCase
         $httpGuzzleResponse = new HttpGuzzleResponse($this->responseInterface->reveal());
 
         $result = $httpGuzzleResponse->json();
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertEquals($dummyBody, $result);
     }
 }

--- a/test/unit/Component/Http/HttpGuzzleResponseTest.php
+++ b/test/unit/Component/Http/HttpGuzzleResponseTest.php
@@ -15,7 +15,7 @@ class HttpGuzzleResponseTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $responseInterface;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->responseInterface = $this->prophesize('Psr\Http\Message\ResponseInterface');
     }

--- a/test/unit/Component/RemoteClients/ChronosApiClientTest.php
+++ b/test/unit/Component/RemoteClients/ChronosApiClientTest.php
@@ -14,7 +14,7 @@ use Chapi\Entity\Chronos\ChronosJobEntity;
 use Chapi\Exception\HttpConnectionException;
 use Prophecy\Argument;
 
-class ChronosApiClientTest extends \PHPUnit_Framework_TestCase
+class ChronosApiClientTest extends \PHPUnit\Framework\TestCase
 {
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $httpClient;

--- a/test/unit/Component/RemoteClients/ChronosApiClientTest.php
+++ b/test/unit/Component/RemoteClients/ChronosApiClientTest.php
@@ -25,7 +25,7 @@ class ChronosApiClientTest extends \PHPUnit\Framework\TestCase
     /**
      *
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->httpClient = $this->prophesize('Chapi\Component\Http\HttpClientInterface');
         $this->httpResponse = $this->prophesize('Chapi\Component\Http\HttpClientResponseInterface');

--- a/test/unit/Component/RemoteClients/ChronosApiClientTest.php
+++ b/test/unit/Component/RemoteClients/ChronosApiClientTest.php
@@ -137,11 +137,10 @@ class ChronosApiClientTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($apiClient->addingJob($testJobEntity));
     }
 
-    /**
-     * @expectedException \Chapi\Exception\ApiClientException
-     */
     public function testAddingJobFailure()
     {
+        $this->expectException(\Chapi\Exception\ApiClientException::class);
+
         $testJobEntity = new ChronosJobEntity();
 
         $this->httpClient->postJsonData()
@@ -224,11 +223,10 @@ class ChronosApiClientTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($apiClient->updatingJob($testJobEntity));
     }
 
-    /**
-     * @expectedException \Chapi\Exception\ApiClientException
-     */
     public function testUpdatingJobFailure()
     {
+        $this->expectException(\Chapi\Exception\ApiClientException::class);
+
         $testJobEntity = new ChronosJobEntity();
 
         $this->httpClient->postJsonData()

--- a/test/unit/Component/RemoteClients/MarathonApiClientTest.php
+++ b/test/unit/Component/RemoteClients/MarathonApiClientTest.php
@@ -14,7 +14,7 @@ use Chapi\Exception\HttpConnectionException;
 use ChapiTest\src\TestTraits\AppEntityTrait;
 use Prophecy\Argument;
 
-class MarathonApiClientTest extends \PHPUnit_Framework_TestCase
+class MarathonApiClientTest extends \PHPUnit\Framework\TestCase
 {
     use AppEntityTrait;
     /** @var \Prophecy\Prophecy\ObjectProphecy */

--- a/test/unit/Component/RemoteClients/MarathonApiClientTest.php
+++ b/test/unit/Component/RemoteClients/MarathonApiClientTest.php
@@ -23,7 +23,7 @@ class MarathonApiClientTest extends \PHPUnit\Framework\TestCase
     /**  @var \Prophecy\Prophecy\ObjectProphecy */
     private $httpResponse;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->httpClient = $this->prophesize('Chapi\Component\Http\HttpClientInterface');
         $this->httpResponse = $this->prophesize('Chapi\Component\Http\HttpClientResponseInterface');

--- a/test/unit/Entity/Chronos/JobEntityTest.php
+++ b/test/unit/Entity/Chronos/JobEntityTest.php
@@ -21,11 +21,10 @@ class JobEntityTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse(property_exists($jobEntity, 'unknownProperty'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInitFailure()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $jobEntity = new ChronosJobEntity('string');
     }
 
@@ -56,11 +55,10 @@ class JobEntityTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse(property_exists($jobEntity->container, 'unknownProperty'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInitFailureForContainer()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $data = [
             'name' => 'jobname',
             'container' => 'foo'

--- a/test/unit/Entity/Chronos/JobEntityTest.php
+++ b/test/unit/Entity/Chronos/JobEntityTest.php
@@ -11,7 +11,7 @@ namespace unit\Entity\Chronos;
 
 use Chapi\Entity\Chronos\ChronosJobEntity;
 
-class JobEntityTest extends \PHPUnit_Framework_TestCase
+class JobEntityTest extends \PHPUnit\Framework\TestCase
 {
     public function testInitSuccess()
     {
@@ -67,7 +67,7 @@ class JobEntityTest extends \PHPUnit_Framework_TestCase
         ];
         $jobEntity = new ChronosJobEntity($data);
     }
-    
+
     public function testGetSimpleArrayCopy()
     {
         $parents = ['jobA', 'jobB'];

--- a/test/unit/Entity/Marathon/AppEntity/ContainerTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/ContainerTest.php
@@ -11,7 +11,7 @@ namespace unit\Entity\Marathon\AppEntity;
 
 use Chapi\Entity\Marathon\AppEntity\Container;
 
-class ContainerTest extends \PHPUnit_Framework_TestCase
+class ContainerTest extends \PHPUnit\Framework\TestCase
 {
     public function testContainerSetProperly()
     {

--- a/test/unit/Entity/Marathon/AppEntity/ContainerVolumeTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/ContainerVolumeTest.php
@@ -10,7 +10,7 @@ namespace unit\Entity\Marathon\AppEntity;
 
 use Chapi\Entity\Marathon\AppEntity\ContainerVolume;
 
-class ContainerVolumeTest extends \PHPUnit_Framework_TestCase
+class ContainerVolumeTest extends \PHPUnit\Framework\TestCase
 {
     public function testAllKeysAreCorrect()
     {

--- a/test/unit/Entity/Marathon/AppEntity/DockerParametersTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/DockerParametersTest.php
@@ -10,7 +10,7 @@ namespace unit\Entity\Marathon\AppEntity;
 
 use Chapi\Entity\Marathon\AppEntity\DockerParameters;
 
-class DockerParametersTest extends \PHPUnit_Framework_TestCase
+class DockerParametersTest extends \PHPUnit\Framework\TestCase
 {
     public function testAllKeysAreCorrect()
     {

--- a/test/unit/Entity/Marathon/AppEntity/DockerPortMappingTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/DockerPortMappingTest.php
@@ -10,7 +10,7 @@ namespace unit\Entity\Marathon\AppEntity;
 
 use Chapi\Entity\Marathon\AppEntity\DockerPortMapping;
 
-class DockerPortMappingTest extends \PHPUnit_Framework_TestCase
+class DockerPortMappingTest extends \PHPUnit\Framework\TestCase
 {
     public function testAllKeysAreCorrect()
     {

--- a/test/unit/Entity/Marathon/AppEntity/DockerTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/DockerTest.php
@@ -12,7 +12,7 @@ use Chapi\Entity\Marathon\AppEntity\Docker;
 use Chapi\Entity\Marathon\AppEntity\DockerParameters;
 use Chapi\Entity\Marathon\AppEntity\DockerPortMapping;
 
-class DockerTest extends \PHPUnit_Framework_TestCase
+class DockerTest extends \PHPUnit\Framework\TestCase
 {
     public function testDockerSetProperly()
     {

--- a/test/unit/Entity/Marathon/AppEntity/HealthCheckTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/HealthCheckTest.php
@@ -10,7 +10,7 @@ namespace unit\Entity\Marathon\AppEntity;
 
 use Chapi\Entity\Marathon\AppEntity\HealthCheck;
 
-class HealthCheckTest extends \PHPUnit_Framework_TestCase
+class HealthCheckTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testCheckAllKeysAreCorrect()

--- a/test/unit/Entity/Marathon/AppEntity/IpAddressTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/IpAddressTest.php
@@ -10,12 +10,12 @@ namespace unit\Entity\Marathon\AppEntity;
 
 use Chapi\Entity\Marathon\AppEntity\IpAddress;
 
-class IpAddressTest extends \PHPUnit_Framework_TestCase
+class IpAddressTest extends \PHPUnit\Framework\TestCase
 {
     public function testAllKeysAreCorrect()
     {
         $keys = ["groups", "labels", "networkName"];
-        
+
         $ipAddress = new IpAddress();
         foreach ($keys as $property) {
             $this->assertObjectHasAttribute($property, $ipAddress);

--- a/test/unit/Entity/Marathon/AppEntity/PortDefinitionTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/PortDefinitionTest.php
@@ -10,7 +10,7 @@ namespace unit\Entity\Marathon\AppEntity;
 
 use Chapi\Entity\Marathon\AppEntity\PortDefinition;
 
-class PortDefinitionTest extends \PHPUnit_Framework_TestCase
+class PortDefinitionTest extends \PHPUnit\Framework\TestCase
 {
     public function testPortDefinitionsSetProperly()
     {

--- a/test/unit/Entity/Marathon/AppEntity/UpgradeStrategyTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/UpgradeStrategyTest.php
@@ -10,7 +10,7 @@ namespace unit\Entity\Marathon\AppEntity;
 
 use Chapi\Entity\Marathon\AppEntity\UpgradeStrategy;
 
-class UpgradeStrategyTest extends \PHPUnit_Framework_TestCase
+class UpgradeStrategyTest extends \PHPUnit\Framework\TestCase
 {
     public function testAllKeysAreCorrect()
     {

--- a/test/unit/Entity/Marathon/MarathonAppEntityTest.php
+++ b/test/unit/Entity/Marathon/MarathonAppEntityTest.php
@@ -13,7 +13,7 @@ use Chapi\Entity\Marathon\AppEntity\PortDefinition;
 use Chapi\Entity\Marathon\MarathonAppEntity;
 use ChapiTest\src\TestTraits\AppEntityTrait;
 
-class MarathonAppEntityTest extends \PHPUnit_Framework_TestCase
+class MarathonAppEntityTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testLiteralValuesSetWithArray()

--- a/test/unit/Service/Chronos/JobStatsServiceTest.php
+++ b/test/unit/Service/Chronos/JobStatsServiceTest.php
@@ -23,7 +23,7 @@ class JobStatsServiceTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $cache;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->apiClient = $this->prophesize('Chapi\Component\RemoteClients\ApiClientInterface');
         $this->cache = $this->prophesize('Chapi\Component\Cache\CacheInterface');

--- a/test/unit/Service/Chronos/JobStatsServiceTest.php
+++ b/test/unit/Service/Chronos/JobStatsServiceTest.php
@@ -15,7 +15,7 @@ use Chapi\Component\RemoteClients\ApiClientInterface;
 use Chapi\Service\Chronos\JobStatsService;
 use Prophecy\Argument;
 
-class JobStatsServiceTest extends \PHPUnit_Framework_TestCase
+class JobStatsServiceTest extends \PHPUnit\Framework\TestCase
 {
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $apiClient;

--- a/test/unit/Service/JobDependency/JobDependencyServiceTest.php
+++ b/test/unit/Service/JobDependency/JobDependencyServiceTest.php
@@ -14,7 +14,7 @@ namespace unit\Service\JobDependency;
 use Chapi\Service\JobDependencies\JobDependencyService;
 use ChapiTest\src\TestTraits\JobEntityTrait;
 
-class JobDependencyServiceTest extends \PHPUnit_Framework_TestCase
+class JobDependencyServiceTest extends \PHPUnit\Framework\TestCase
 {
     use JobEntityTrait;
 

--- a/test/unit/Service/JobDependency/JobDependencyServiceTest.php
+++ b/test/unit/Service/JobDependency/JobDependencyServiceTest.php
@@ -24,7 +24,7 @@ class JobDependencyServiceTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $jobRepositoryChronos;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->jobRepositoryChronos = $this->prophesize('Chapi\Service\JobRepository\JobRepositoryInterface');
         $this->jobRepositoryLocal = $this->prophesize('Chapi\Service\JobRepository\JobRepositoryInterface');

--- a/test/unit/Service/JobIndex/JobIndexServiceTest.php
+++ b/test/unit/Service/JobIndex/JobIndexServiceTest.php
@@ -11,7 +11,7 @@ namespace unit\Service\JobIndex;
 use Chapi\Service\JobIndex\JobIndexService;
 use Prophecy\Argument;
 
-class JobIndexServiceTest extends \PHPUnit_Framework_TestCase
+class JobIndexServiceTest extends \PHPUnit\Framework\TestCase
 {
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $cacheInterface;

--- a/test/unit/Service/JobIndex/JobIndexServiceTest.php
+++ b/test/unit/Service/JobIndex/JobIndexServiceTest.php
@@ -19,7 +19,7 @@ class JobIndexServiceTest extends \PHPUnit\Framework\TestCase
     /** @var array  */
     private $testJobIndex = ['JobA' => 'JobA', 'JobB' => 'JobB'];
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->cacheInterface = $this->prophesize('Chapi\Component\Cache\CacheInterface');
 

--- a/test/unit/Service/JobRepository/BridgeChronosTest.php
+++ b/test/unit/Service/JobRepository/BridgeChronosTest.php
@@ -35,7 +35,7 @@ class BridgeChronosTest extends \PHPUnit\Framework\TestCase
 
     private $listingJobs = [];
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->listingJobs = json_decode($this->jsonListingJobs, true);
 

--- a/test/unit/Service/JobRepository/BridgeChronosTest.php
+++ b/test/unit/Service/JobRepository/BridgeChronosTest.php
@@ -87,10 +87,7 @@ class BridgeChronosTest extends \PHPUnit\Framework\TestCase
 
         $jobs = $jobRepositoryChronos->getJobs();
 
-        $this->assertInternalType(
-            'array',
-            $jobs
-        );
+        $this->assertIsArray($jobs);
 
         $this->assertInstanceOf(
             'Chapi\Entity\Chronos\ChronosJobEntity',
@@ -135,10 +132,7 @@ class BridgeChronosTest extends \PHPUnit\Framework\TestCase
 
         $jobs = $jobRepositoryChronos->getJobs();
 
-        $this->assertInternalType(
-            'array',
-            $jobs
-        );
+        $this->assertIsArray($jobs);
 
         $this->assertInstanceOf(
             'Chapi\Entity\Chronos\ChronosJobEntity',

--- a/test/unit/Service/JobRepository/BridgeChronosTest.php
+++ b/test/unit/Service/JobRepository/BridgeChronosTest.php
@@ -15,7 +15,7 @@ use Chapi\Service\JobRepository\BridgeChronos;
 use ChapiTest\src\TestTraits\JobEntityTrait;
 use Prophecy\Argument;
 
-class BridgeChronosTest extends \PHPUnit_Framework_TestCase
+class BridgeChronosTest extends \PHPUnit\Framework\TestCase
 {
     use JobEntityTrait;
 

--- a/test/unit/Service/JobRepository/BridgeFileSystemTest.php
+++ b/test/unit/Service/JobRepository/BridgeFileSystemTest.php
@@ -17,7 +17,7 @@ use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamWrapper;
 
-class BridgeFileSystemTest extends \PHPUnit_Framework_TestCase
+class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
 {
     use JobEntityTrait;
     use AppEntityTrait;

--- a/test/unit/Service/JobRepository/BridgeFileSystemTest.php
+++ b/test/unit/Service/JobRepository/BridgeFileSystemTest.php
@@ -37,7 +37,7 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
     /** @var string  */
     private $tempTestDir = '';
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->fileSystemService = $this->prophesize('Symfony\Component\Filesystem\Filesystem');
 
@@ -75,7 +75,7 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
         rmdir($path);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->rmrf($this->tempTestDir);
     }

--- a/test/unit/Service/JobRepository/BridgeFileSystemTest.php
+++ b/test/unit/Service/JobRepository/BridgeFileSystemTest.php
@@ -353,12 +353,10 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, count($remainingApps), 'Expected 1 app remaining after removal, found ' . count($remainingApps));
     }
 
-
-    /**
-     * @expectedException \Chapi\Exception\JobLoadException
-     */
     public function testJobLoadException()
     {
+        $this->expectException(\Chapi\Exception\JobLoadException::class);
+
         $structure = array(
             'directory' => array(
                 'jobA.json' => 'no-json-string',
@@ -378,11 +376,10 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($jobs);
     }
 
-    /**
-     * @expectedException \Chapi\Exception\JobLoadException
-     */
     public function testJobLoadExceptionForDuplicateJobNames()
     {
+        $this->expectException(\Chapi\Exception\JobLoadException::class);
+
         $structure = array(
             'directory' => array(
                 'jobA.json' => json_encode($this->getValidScheduledJobEntity('JobA')),

--- a/test/unit/Service/JobRepository/BridgeMarathonTest.php
+++ b/test/unit/Service/JobRepository/BridgeMarathonTest.php
@@ -32,7 +32,8 @@ class BridgeMarathonTest extends \PHPUnit\Framework\TestCase
     private $jsonApps = '{"apps":[{"id":"/bots/runner","cmd":"chmod +x run.sh && ./run.sh","args":null,"user":null,"env":{"APP_GROUP":"131441"},"instances":1,"cpus":0.5,"mem":128,"disk":30,"executor":"","constraints":[],"uris":["https://raw.githubusercontent.com/test/testrepo/master/run.sh"],"fetch":[{"uri":"https://raw.githubusercontent.com/test/testrepo/master/run.sh","extract":false,"executable":false,"cache":false}],"storeUrls":[],"ports":[10310],"portDefinitions":[{"port":10310,"protocol":"tcp","labels":{}}],"requirePorts":false,"backoffSeconds":1,"backoffFactor":1.15,"maxLaunchDelaySeconds":3600,"container":null,"healthChecks":[{"path":"/health","protocol":"HTTP","portIndex":0,"gracePeriodSeconds":60,"intervalSeconds":10,"timeoutSeconds":10,"maxConsecutiveFailures":3,"ignoreHttp1xx":false}],"readinessChecks":[],"dependencies":[],"upgradeStrategy":{"minimumHealthCapacity":1,"maximumOverCapacity":1},"labels":{"app_label":"operation"},"acceptedResourceRoles":null,"ipAddress":null,"version":"2016-08-02T08:15:37.666Z","residency":null,"versionInfo":{"lastScalingAt":"2016-08-02T08:15:37.666Z","lastConfigChangeAt":"2016-08-02T08:15:37.666Z"},"tasksStaged":0,"tasksRunning":1,"tasksHealthy":1,"tasksUnhealthy":0,"deployments":[]}]}';
 
     private $listingJobs;
-    public function setup()
+
+    protected function setUp(): void
     {
         $this->listingJobs = json_decode($this->jsonApps, true);
         $this->apiClient = $this->prophesize('Chapi\Component\RemoteClients\ApiClientInterface');

--- a/test/unit/Service/JobRepository/BridgeMarathonTest.php
+++ b/test/unit/Service/JobRepository/BridgeMarathonTest.php
@@ -48,40 +48,6 @@ class BridgeMarathonTest extends \PHPUnit\Framework\TestCase
         $this->logger = $this->prophesize('Psr\Log\LoggerInterface');
     }
 
-    public function testGetJobsSuccess()
-    {
-        $this->cache
-            ->get(Argument::exact(BridgeMarathon::CACHE_KEY_APP_LIST))
-            ->willReturn([]);
-
-        $this->cache
-            ->set(BridgeMarathon::CACHE_KEY_APP_LIST, Argument::exact($this->listingJobs["apps"]), BridgeMarathon::CACHE_TIME_JOB_LIST);
-
-        $marathonBridge = new BridgeMarathon(
-            $this->apiClient->reveal(),
-            $this->cache->reveal(),
-            $this->jobValidatorService->reveal(),
-            $this->logger->reveal()
-        );
-
-        $apps = $marathonBridge->getJobs();
-
-        foreach ($apps as $gotApp) {
-            $this->assertInstanceOf('Chapi\Entity\JobEntityInterface', 'Entity expected to be fullfill of JobEntityInterface interface');
-            $this->assertInstanceOf('Chapi\Entity\Marathon\MarathonAppEntity', 'Entity expected to be instance of MarathonAppEntity');
-
-            $found = false;
-            foreach ($this->listingJobs["apps"] as $listedApp) {
-                if ($gotApp->getKey() == $listedApp["id"]) {
-                    $found = true;
-                    break;
-                }
-            }
-            $this->assertTrue($found, 'Expected job not found');
-        }
-    }
-
-
     public function testAddJobSuccess()
     {
         $app = $this->getValidMarathonAppEntity("/mygroup/myapp");

--- a/test/unit/Service/JobRepository/BridgeMarathonTest.php
+++ b/test/unit/Service/JobRepository/BridgeMarathonTest.php
@@ -13,7 +13,7 @@ use Chapi\Service\JobRepository\BridgeMarathon;
 use ChapiTest\src\TestTraits\AppEntityTrait;
 use Prophecy\Argument;
 
-class BridgeMarathonTest extends \PHPUnit_Framework_TestCase
+class BridgeMarathonTest extends \PHPUnit\Framework\TestCase
 {
     use AppEntityTrait;
 

--- a/test/unit/Service/JobRepository/Filter/FilterIgnoreSettingsTest.php
+++ b/test/unit/Service/JobRepository/Filter/FilterIgnoreSettingsTest.php
@@ -24,7 +24,7 @@ class FilterIgnoreSettingsTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $chapiConfig;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->logger = $this->prophesize('Psr\Log\LoggerInterface');
 

--- a/test/unit/Service/JobRepository/Filter/FilterIgnoreSettingsTest.php
+++ b/test/unit/Service/JobRepository/Filter/FilterIgnoreSettingsTest.php
@@ -13,7 +13,7 @@ use Chapi\Service\JobRepository\Filter\FilterIgnoreSettings;
 use ChapiTest\src\TestTraits\AppEntityTrait;
 use ChapiTest\src\TestTraits\JobEntityTrait;
 
-class FilterIgnoreSettingsTest extends \PHPUnit_Framework_TestCase
+class FilterIgnoreSettingsTest extends \PHPUnit\Framework\TestCase
 {
     use JobEntityTrait;
     use AppEntityTrait;

--- a/test/unit/Service/JobRepository/JobRepositoryTest.php
+++ b/test/unit/Service/JobRepository/JobRepositoryTest.php
@@ -25,7 +25,7 @@ class JobRepositoryTest extends \PHPUnit\Framework\TestCase
     /** @var  \Prophecy\Prophecy\ObjectProphecy */
     private $entityFilter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->repositoryBridge = $this->prophesize('Chapi\Service\JobRepository\BridgeInterface');
         $this->entityFilter = $this->prophesize('Chapi\Service\JobRepository\Filter\JobFilterInterface');

--- a/test/unit/Service/JobRepository/JobRepositoryTest.php
+++ b/test/unit/Service/JobRepository/JobRepositoryTest.php
@@ -15,7 +15,7 @@ use Chapi\Service\JobRepository\JobRepository;
 use ChapiTest\src\TestTraits\JobEntityTrait;
 use Prophecy\Argument;
 
-class JobRepositoryTest extends \PHPUnit_Framework_TestCase
+class JobRepositoryTest extends \PHPUnit\Framework\TestCase
 {
     use JobEntityTrait;
 

--- a/test/unit/Service/JobRepository/JobRepositoryTest.php
+++ b/test/unit/Service/JobRepository/JobRepositoryTest.php
@@ -334,11 +334,10 @@ class JobRepositoryTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRemoveJobFailureException()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->repositoryBridge
             ->removeJob(Argument::any())
             ->shouldNotBeCalled()

--- a/test/unit/Service/JobValidator/JobEntityValidatorServiceTest.php
+++ b/test/unit/Service/JobValidator/JobEntityValidatorServiceTest.php
@@ -14,7 +14,7 @@ use Chapi\Service\JobValidator\ChronosJobValidatorService;
 use ChapiTest\src\TestTraits\JobEntityTrait;
 use Prophecy\Argument;
 
-class JobEntityValidatorServiceTest extends \PHPUnit_Framework_TestCase
+class JobEntityValidatorServiceTest extends \PHPUnit\Framework\TestCase
 {
     use JobEntityTrait;
 
@@ -29,7 +29,7 @@ class JobEntityValidatorServiceTest extends \PHPUnit_Framework_TestCase
         $this->propertyValidator = $this->prophesize('Chapi\Service\JobValidator\PropertyValidatorInterface');
         $this->validatorFactory = $this->prophesize('Chapi\Service\JobValidator\ValidatorFactoryInterface');
     }
-    
+
     public function testIsEntityValidSuccess()
     {
         // mock
@@ -78,7 +78,7 @@ class JobEntityValidatorServiceTest extends \PHPUnit_Framework_TestCase
         $this->propertyValidator->isValid(Argument::type('string'), Argument::type('Chapi\Entity\Chronos\ChronosJobEntity'))->shouldHaveBeenCalled();
         $this->propertyValidator->getLastErrorMessage()->shouldHaveBeenCalled();
     }
-    
+
     public function testGetInvalidPropertiesSuccess()
     {
         // mock
@@ -92,7 +92,7 @@ class JobEntityValidatorServiceTest extends \PHPUnit_Framework_TestCase
         $jobEntityValidatorService = new ChronosJobValidatorService(
             $this->validatorFactory->reveal()
         );
-        
+
         // test
         $this->assertEquals(
             0,
@@ -116,12 +116,12 @@ class JobEntityValidatorServiceTest extends \PHPUnit_Framework_TestCase
 
         // test
         $result = $jobEntityValidatorService->getInvalidProperties($jobEntity);
-        
+
         $this->assertGreaterThan(
             0,
             count($result)
         );
-        
+
         foreach ($result as $errorMessage) {
             $this->assertEquals('error message', $errorMessage);
             break; // one check is enough

--- a/test/unit/Service/JobValidator/JobEntityValidatorServiceTest.php
+++ b/test/unit/Service/JobValidator/JobEntityValidatorServiceTest.php
@@ -24,7 +24,7 @@ class JobEntityValidatorServiceTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $validatorFactory;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->propertyValidator = $this->prophesize('Chapi\Service\JobValidator\PropertyValidatorInterface');
         $this->validatorFactory = $this->prophesize('Chapi\Service\JobValidator\ValidatorFactoryInterface');

--- a/test/unit/Service/JobValidator/PropertyValidator/AbstractValidatorTest.php
+++ b/test/unit/Service/JobValidator/PropertyValidator/AbstractValidatorTest.php
@@ -14,7 +14,7 @@ use Chapi\Entity\JobEntityInterface;
 use Chapi\Service\JobValidator\PropertyValidatorInterface;
 use ChapiTest\src\TestTraits\JobEntityTrait;
 
-abstract class AbstractValidatorTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractValidatorTest extends \PHPUnit\Framework\TestCase
 {
     use JobEntityTrait;
 
@@ -35,7 +35,7 @@ abstract class AbstractValidatorTest extends \PHPUnit_Framework_TestCase
         if (is_null($jobEntity)) {
             $jobEntity = $this->getValidScheduledJobEntity();
         }
-        
+
         $jobEntity->{$property} = $invalidValue;
         $this->assertFalse($validator->isValid($property, $jobEntity));
         $this->assertContains($property, $validator->getLastErrorMessage());
@@ -60,7 +60,7 @@ abstract class AbstractValidatorTest extends \PHPUnit_Framework_TestCase
         if (is_null($jobEntity)) {
             $jobEntity = $this->getValidScheduledJobEntity();
         }
-        
+
         $jobEntity->{$property} = $validValue;
         $this->assertTrue($validator->isValid($property, $jobEntity));
         $this->assertEmpty($validator->getLastErrorMessage());
@@ -81,7 +81,7 @@ abstract class AbstractValidatorTest extends \PHPUnit_Framework_TestCase
         if (is_null($jobEntity)) {
             $jobEntity = $this->getValidScheduledJobEntity();
         }
-        
+
         $jobEntity->{$property} = $invalidValue;
         $this->assertFalse($validator->isValid($property, $jobEntity));
         $this->assertContains($property, $validator->getLastErrorMessage());

--- a/test/unit/Service/JobValidator/PropertyValidator/AbstractValidatorTest.php
+++ b/test/unit/Service/JobValidator/PropertyValidator/AbstractValidatorTest.php
@@ -38,7 +38,7 @@ abstract class AbstractValidatorTest extends \PHPUnit\Framework\TestCase
 
         $jobEntity->{$property} = $invalidValue;
         $this->assertFalse($validator->isValid($property, $jobEntity));
-        $this->assertContains($property, $validator->getLastErrorMessage());
+        $this->assertStringContainsString($property, $validator->getLastErrorMessage());
 
         $jobEntity->{$property} = $validValue;
         $this->assertTrue($validator->isValid($property, $jobEntity));
@@ -84,6 +84,6 @@ abstract class AbstractValidatorTest extends \PHPUnit\Framework\TestCase
 
         $jobEntity->{$property} = $invalidValue;
         $this->assertFalse($validator->isValid($property, $jobEntity));
-        $this->assertContains($property, $validator->getLastErrorMessage());
+        $this->assertStringContainsString($property, $validator->getLastErrorMessage());
     }
 }

--- a/test/unit/Service/JobValidator/PropertyValidator/EpsilonTest.php
+++ b/test/unit/Service/JobValidator/PropertyValidator/EpsilonTest.php
@@ -22,16 +22,16 @@ class EpsilonTest extends AbstractValidatorTest
 
     use JobEntityTrait;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->datePeriodFactory = $this->prophesize('Chapi\Component\DatePeriod\DatePeriodFactoryInterface');
     }
-    
+
     public function testIsValidSuccess()
     {
         $jobEntity= $this->setUpEntityByInterval('PT30M');
         $propertyValidator = new Epsilon($this->datePeriodFactory->reveal());
-        
+
         $this->handleValidTestCase($propertyValidator, 'epsilon', 'PT5M', $jobEntity);
         $this->handleValidTestCase($propertyValidator, 'epsilon', 'PT15M', $jobEntity);
 
@@ -64,7 +64,7 @@ class EpsilonTest extends AbstractValidatorTest
     {
         $jobEntity= $this->setUpEntityByInterval('PT1H');
         $propertyValidator = new Epsilon($this->datePeriodFactory->reveal());
-        
+
         $this->handleErrorMessageMultiTestCase($propertyValidator, 'epsilon', 'PT15M', 'PT120M', $jobEntity);
     }
 

--- a/test/unit/Service/JobValidator/PropertyValidator/ScheduleTest.php
+++ b/test/unit/Service/JobValidator/PropertyValidator/ScheduleTest.php
@@ -22,7 +22,7 @@ class ScheduleTest extends AbstractValidatorTest
 
     use JobEntityTrait;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->datePeriodFactory = $this->prophesize('Chapi\Component\DatePeriod\DatePeriodFactoryInterface');
     }
@@ -39,7 +39,7 @@ class ScheduleTest extends AbstractValidatorTest
                 )
             )
         ;
-        
+
         $propertyValidator = new Schedule($this->datePeriodFactory->reveal());
 
         $this->handleValidTestCase($propertyValidator, 'schedule', 'foo');
@@ -63,10 +63,10 @@ class ScheduleTest extends AbstractValidatorTest
 
         $jobEntity = $this->getValidDependencyJobEntity();
         $this->handleInvalidTestCase($propertyValidator, 'parents', [], $jobEntity);
-        
+
         // test with createDatePeriod return value
         $this->handleInvalidTestCase($propertyValidator, 'schedule', 'foo');
-        
+
         // Spies
         $this->datePeriodFactory
             ->createDatePeriod(Argument::type('string'), Argument::type('string'))
@@ -90,7 +90,7 @@ class ScheduleTest extends AbstractValidatorTest
     public function testIsValidFailureForDependencyJobWithScheduling()
     {
         $propertyValidator = new Schedule($this->datePeriodFactory->reveal());
-        
+
         // test !empty schedule property
         $jobEntity = $this->getValidDependencyJobEntity();
         $jobEntity->schedule = 'R/2015-09-01T02:00:00Z/P1M';
@@ -109,9 +109,9 @@ class ScheduleTest extends AbstractValidatorTest
                 )
             )
         ;
-        
+
         $propertyValidator = new Schedule($this->datePeriodFactory->reveal());
-        
+
         $this->handleErrorMessageMultiTestCase($propertyValidator, 'schedule', 'foo', '');
     }
 }


### PR DESCRIPTION
This PR does a lot (related to the unit tests):

- Update PHPUnit: 5.7.21 -> 8.5.5
- Remove phpunit/phpunit-mock-objects, because it is obsolete
- Modify unit tests to use the current features instead of deprecated ones