### PR TITLE
Improve PHP version requirements and assertions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ before_script:
 script: ./bin/phpunit --coverage-clover=coverage.clover -c test/phpunit.xml test/
 
 after_script:
-  - if [ "$TRAVIS_PHP_VERSION" == "7.0" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "7.0" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "7.2" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "7.2" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "require": {
-    "php": ">=5.6.0",
+    "php": ">=7.2.0",
     "symfony/console": "~3.0",
     "symfony/dependency-injection": "~3.0",
     "symfony/yaml": "~3.0",

--- a/test/unit/BusinessCase/Comparison/CompositeJobComparisonBusinessCaseTest.php
+++ b/test/unit/BusinessCase/Comparison/CompositeJobComparisonBusinessCaseTest.php
@@ -51,7 +51,7 @@ class CompositeJobComparisonBusinessCaseTest extends \PHPUnit\Framework\TestCase
 
         $missingJobs =  $compositeJobComparison->getLocalMissingJobs();
 
-        $this->assertEquals(2, count($missingJobs), "Expected 2 elements, got only " . count($missingJobs));
+        $this->assertCount(2, $missingJobs, "Expected 2 elements, got only " . count($missingJobs));
     }
 
     public function testGetRemoteMissingJobs()
@@ -77,7 +77,7 @@ class CompositeJobComparisonBusinessCaseTest extends \PHPUnit\Framework\TestCase
 
         $missingJobs =  $compositeJobComparison->getRemoteMissingJobs();
 
-        $this->assertEquals(2, count($missingJobs), "Expected 2 elements, got only " . count($missingJobs));
+        $this->assertCount(2, $missingJobs, "Expected 2 elements, got only " . count($missingJobs));
     }
 
     public function testGetLocalJobUpdates()
@@ -103,7 +103,7 @@ class CompositeJobComparisonBusinessCaseTest extends \PHPUnit\Framework\TestCase
 
         $updatedJobs = $compositeJobComparison->getLocalJobUpdates();
 
-        $this->assertEquals(2, count($updatedJobs), "Expected 2 elements, got only " . count($updatedJobs));
+        $this->assertCount(2, $updatedJobs, "Expected 2 elements, got only " . count($updatedJobs));
     }
 
     public function testGetJobDiffForMarathonCaseSuccess()

--- a/test/unit/BusinessCase/Comparison/MarathonJobComparisonBusinessCaseTest.php
+++ b/test/unit/BusinessCase/Comparison/MarathonJobComparisonBusinessCaseTest.php
@@ -7,7 +7,7 @@
  *
  */
 
-namespace unit\BusinessCase\Comparision;
+namespace unit\BusinessCase\Comparison;
 
 use Chapi\BusinessCase\Comparison\MarathonJobComparisonBusinessCase;
 use Chapi\Entity\Marathon\AppEntity\Container;
@@ -62,10 +62,10 @@ class MarathonJobComparisonBusinessCaseTest extends \PHPUnit\Framework\TestCase
 
         $localMissingJobs = $marathonJobCompare->getLocalMissingJobs();
 
-        $this->assertEquals(1, count($localMissingJobs), 'Expected 1 job, got ' . count($localMissingJobs));
+        $this->assertCount(1, $localMissingJobs, 'Expected 1 job, got ' . count($localMissingJobs));
 
         $gotKey = $localMissingJobs[0];
-        $this->assertEquals("/main/id1", $gotKey, 'Expected ”/main/id1", received ' . $gotKey);
+        $this->assertSame("/main/id1", $gotKey, 'Expected ”/main/id1", received ' . $gotKey);
     }
 
     public function testGetRemoteMissingJobsSuccess()
@@ -90,10 +90,10 @@ class MarathonJobComparisonBusinessCaseTest extends \PHPUnit\Framework\TestCase
 
         $remoteMissingJobs = $marathonJobCompare->getRemoteMissingJobs();
 
-        $this->assertEquals(1, count($remoteMissingJobs), 'Expected 1 job, got ' . count($remoteMissingJobs));
+        $this->assertCount(1, $remoteMissingJobs, 'Expected 1 job, got ' . count($remoteMissingJobs));
 
         $gotKey = $remoteMissingJobs[0];
-        $this->assertEquals("/main/id1", $gotKey, 'Expected ”/main/id1", received ' . $gotKey);
+        $this->assertSame("/main/id1", $gotKey, 'Expected ”/main/id1", received ' . $gotKey);
     }
 
     public function testGetLocalJobUpdatesSuccess()
@@ -127,9 +127,9 @@ class MarathonJobComparisonBusinessCaseTest extends \PHPUnit\Framework\TestCase
 
         $updatedApps = $marathonJobCompare->getLocalJobUpdates();
 
-        $this->assertEquals(1, count($updatedApps), 'Expected 1 job, got ' . count($updatedApps));
+        $this->assertCount(1, $updatedApps, 'Expected 1 job, got ' . count($updatedApps));
 
-        $this->assertEquals('/main/id2', $updatedApps[0], 'Expected "/main/id2", received ' . $updatedApps[0]);
+        $this->assertSame('/main/id2', $updatedApps[0], 'Expected "/main/id2", received ' . $updatedApps[0]);
     }
 
     public function testGetLocalUpdatesCallsPreCompareModification()

--- a/test/unit/Command/AbstractCommandTest.php
+++ b/test/unit/Command/AbstractCommandTest.php
@@ -44,7 +44,7 @@ class AbstractCommandTest extends \PHPUnit\Framework\TestCase
 
         $this->assertStringContainsString('.chapi', $command->getHomeDirPub());
         $this->assertStringContainsString($homeDir, $command->getHomeDirPub());
-        $this->assertTrue(is_dir($command->getHomeDirPub()));
+        $this->assertDirectoryExists($command->getHomeDirPub());
     }
 
     public function testGetCacheDir()
@@ -53,7 +53,7 @@ class AbstractCommandTest extends \PHPUnit\Framework\TestCase
         $command::$containerDummy = $this->container->reveal();
 
         $this->assertStringContainsString('cache', $command->getCacheDir());
-        $this->assertTrue(is_dir($command->getCacheDir()));
+        $this->assertDirectoryExists($command->getCacheDir());
     }
 
     public function testIsAppRuanableWithLocalConfig()
@@ -130,6 +130,6 @@ class AbstractCommandTest extends \PHPUnit\Framework\TestCase
             $this->output->reveal()
         );
 
-        $this->assertEquals('.chapiconfig', $command->getParameterFileNamePub());
+        $this->assertSame('.chapiconfig', $command->getParameterFileNamePub());
     }
 }

--- a/test/unit/Command/AddCommandTest.php
+++ b/test/unit/Command/AddCommandTest.php
@@ -42,7 +42,7 @@ class AddCommandTest extends \PHPUnit\Framework\TestCase
         $command = new AddCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),
@@ -77,7 +77,7 @@ class AddCommandTest extends \PHPUnit\Framework\TestCase
         $command = new AddCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),

--- a/test/unit/Command/ConfigureCommandTest.php
+++ b/test/unit/Command/ConfigureCommandTest.php
@@ -73,7 +73,7 @@ class ConfigureCommandTest extends \PHPUnit\Framework\TestCase
         $command = new ConfigureCommandDummy();
         $command::$questionHelperDummy = $this->questionHelper->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),
@@ -81,7 +81,7 @@ class ConfigureCommandTest extends \PHPUnit\Framework\TestCase
             )
         );
 
-        $this->assertTrue(file_exists($this->tempTestDir . DIRECTORY_SEPARATOR . '.chapiconfig'));
+        $this->assertFileExists($this->tempTestDir . DIRECTORY_SEPARATOR . '.chapiconfig');
     }
 
     public function testConfigureWithArgumentsSuccess()
@@ -108,7 +108,7 @@ class ConfigureCommandTest extends \PHPUnit\Framework\TestCase
         $command = new ConfigureCommandDummy();
         $command::$questionHelperDummy = $this->questionHelper->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),
@@ -116,7 +116,7 @@ class ConfigureCommandTest extends \PHPUnit\Framework\TestCase
             )
         );
 
-        $this->assertTrue(file_exists($this->tempTestDir . DIRECTORY_SEPARATOR . '.chapiconfig'));
+        $this->assertFileExists($this->tempTestDir . DIRECTORY_SEPARATOR . '.chapiconfig');
     }
 
     public function testConfigureWithAndWithoutArgumentsSuccess()
@@ -144,7 +144,7 @@ class ConfigureCommandTest extends \PHPUnit\Framework\TestCase
         $command = new ConfigureCommandDummy();
         $command::$questionHelperDummy = $this->questionHelper->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),
@@ -152,7 +152,7 @@ class ConfigureCommandTest extends \PHPUnit\Framework\TestCase
             )
         );
 
-        $this->assertTrue(file_exists($this->tempTestDir . DIRECTORY_SEPARATOR . '.chapiconfig'));
+        $this->assertFileExists($this->tempTestDir . DIRECTORY_SEPARATOR . '.chapiconfig');
     }
 
     public function testConfigureWithoutArgumentsFailure()
@@ -180,7 +180,7 @@ class ConfigureCommandTest extends \PHPUnit\Framework\TestCase
         $command = new ConfigureCommandDummy();
         $command::$questionHelperDummy = $this->questionHelper->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             1,
             $command->run(
                 $this->input->reveal(),
@@ -188,6 +188,6 @@ class ConfigureCommandTest extends \PHPUnit\Framework\TestCase
             )
         );
 
-        $this->assertFalse(file_exists($this->tempTestDir . DIRECTORY_SEPARATOR . '.chapiconfig'));
+        $this->assertFileNotExists($this->tempTestDir . DIRECTORY_SEPARATOR . '.chapiconfig');
     }
 }

--- a/test/unit/Command/InfoCommandTest.php
+++ b/test/unit/Command/InfoCommandTest.php
@@ -40,7 +40,7 @@ class InfoCommandTest extends \PHPUnit\Framework\TestCase
         $command = new InfoCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),

--- a/test/unit/Command/ListCommandTest.php
+++ b/test/unit/Command/ListCommandTest.php
@@ -50,7 +50,7 @@ class ListCommandTest extends \PHPUnit\Framework\TestCase
         $command = new ListCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),
@@ -85,7 +85,7 @@ class ListCommandTest extends \PHPUnit\Framework\TestCase
         $command = new ListCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),
@@ -118,7 +118,7 @@ class ListCommandTest extends \PHPUnit\Framework\TestCase
         $command = new ListCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),

--- a/test/unit/Command/ResetCommandTest.php
+++ b/test/unit/Command/ResetCommandTest.php
@@ -41,7 +41,7 @@ class ResetCommandTest extends \PHPUnit\Framework\TestCase
         $command = new ResetCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),
@@ -66,7 +66,7 @@ class ResetCommandTest extends \PHPUnit\Framework\TestCase
         $_oCommand = new ResetCommandDummy();
         $_oCommand::$containerDummy = $this->container->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $_oCommand->run(
                 $this->input->reveal(),

--- a/test/unit/Command/SchedulingViewCommandTest.php
+++ b/test/unit/Command/SchedulingViewCommandTest.php
@@ -66,7 +66,7 @@ class SchedulingViewCommandTest extends \PHPUnit\Framework\TestCase
         $command = new SchedulingViewCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),
@@ -87,7 +87,7 @@ class SchedulingViewCommandTest extends \PHPUnit\Framework\TestCase
         $command = new SchedulingViewCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),

--- a/test/unit/Command/ValidationCommandTest.php
+++ b/test/unit/Command/ValidationCommandTest.php
@@ -64,7 +64,7 @@ class ValidationCommandTest extends \PHPUnit\Framework\TestCase
         $command = new ValidationCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),
@@ -102,7 +102,7 @@ class ValidationCommandTest extends \PHPUnit\Framework\TestCase
         $command = new ValidationCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             1,
             $command->run(
                 $this->input->reveal(),
@@ -135,7 +135,7 @@ class ValidationCommandTest extends \PHPUnit\Framework\TestCase
         $command = new ValidationCommandDummy();
         $command::$containerDummy = $this->container->reveal();
 
-        $this->assertEquals(
+        $this->assertSame(
             0,
             $command->run(
                 $this->input->reveal(),

--- a/test/unit/Component/Cache/DoctrineCacheTest.php
+++ b/test/unit/Component/Cache/DoctrineCacheTest.php
@@ -83,7 +83,7 @@ class DoctrineCacheTest extends \PHPUnit\Framework\TestCase
 
         $doctrineCache = new DoctrineCache($this->cache->reveal(), 'cache_prefix');
 
-        $this->assertEquals(
+        $this->assertSame(
             $testValue,
             $doctrineCache->get($testKey)
         );

--- a/test/unit/Component/Command/CommandUtilsTest.php
+++ b/test/unit/Component/Command/CommandUtilsTest.php
@@ -20,7 +20,7 @@ class CommandUtilsTest extends \PHPUnit\Framework\TestCase
     {
         putenv('HOME=/var/tmp/');
 
-        $this->assertEquals('/var/tmp', CommandUtils::getOsHomeDir());
+        $this->assertSame('/var/tmp', CommandUtils::getOsHomeDir());
     }
 
     public function testGetOsHomeDirWindows()
@@ -28,7 +28,7 @@ class CommandUtilsTest extends \PHPUnit\Framework\TestCase
         putenv('APPDATA=c:\user\directory\\');
         define('PHP_WINDOWS_VERSION_MAJOR', '8.1');
 
-        $this->assertEquals('c:/user/directory', CommandUtils::getOsHomeDir());
+        $this->assertSame('c:/user/directory', CommandUtils::getOsHomeDir());
     }
 
     public function testHasCreateDirectoryIfNotExists()
@@ -41,6 +41,6 @@ class CommandUtilsTest extends \PHPUnit\Framework\TestCase
             )
         );
 
-        $this->assertTrue(is_dir(vfsStream::url('root/directory')));
+        $this->assertDirectoryExists(vfsStream::url('root/directory'));
     }
 }

--- a/test/unit/Component/Config/ChapiConfigTest.php
+++ b/test/unit/Component/Config/ChapiConfigTest.php
@@ -146,9 +146,9 @@ class ChapiConfigTest extends \PHPUnit\Framework\TestCase
 
         $profileConfig = $chapiConfig->getProfileConfig();
 
-        $this->assertEquals('/tmp/cache/update', $profileConfig['parameters']['cache_dir']);
-        $this->assertEquals('update_user', $profileConfig['parameters']['chronos_http_username']);
-        $this->assertEquals('new_user', $profileConfig['parameters']['marathon_http_username']);
+        $this->assertSame('/tmp/cache/update', $profileConfig['parameters']['cache_dir']);
+        $this->assertSame('update_user', $profileConfig['parameters']['chronos_http_username']);
+        $this->assertSame('new_user', $profileConfig['parameters']['marathon_http_username']);
 
         $this->assertEquals(['*-stage', 'new-entry'], $profileConfig['ignore']);
     }

--- a/test/unit/Component/DatePeriod/DatePeriodFactoryTest.php
+++ b/test/unit/Component/DatePeriod/DatePeriodFactoryTest.php
@@ -19,18 +19,18 @@ class DatePeriodFactoryTest extends \PHPUnit\Framework\TestCase
 
         $iso8601Entity = $datePeriodFactory->createIso8601Entity('R/2015-07-07T01:00:00Z/P1D');
 
-        $this->assertEquals('R/2015-07-07T01:00:00Z/P1D', $iso8601Entity->iso8601);
-        $this->assertEquals('R', $iso8601Entity->repeat);
-        $this->assertEquals('2015-07-07T01:00:00Z', $iso8601Entity->startTime);
-        $this->assertEquals('P1D', $iso8601Entity->interval);
+        $this->assertSame('R/2015-07-07T01:00:00Z/P1D', $iso8601Entity->iso8601);
+        $this->assertSame('R', $iso8601Entity->repeat);
+        $this->assertSame('2015-07-07T01:00:00Z', $iso8601Entity->startTime);
+        $this->assertSame('P1D', $iso8601Entity->interval);
 
 
         $iso8601Entity = $datePeriodFactory->createIso8601Entity('R0/2015-07-07T01:00:00Z/PT1M');
 
-        $this->assertEquals('R0/2015-07-07T01:00:00Z/PT1M', $iso8601Entity->iso8601);
-        $this->assertEquals('R0', $iso8601Entity->repeat);
-        $this->assertEquals('2015-07-07T01:00:00Z', $iso8601Entity->startTime);
-        $this->assertEquals('PT1M', $iso8601Entity->interval);
+        $this->assertSame('R0/2015-07-07T01:00:00Z/PT1M', $iso8601Entity->iso8601);
+        $this->assertSame('R0', $iso8601Entity->repeat);
+        $this->assertSame('2015-07-07T01:00:00Z', $iso8601Entity->startTime);
+        $this->assertSame('PT1M', $iso8601Entity->interval);
     }
 
     public function testParseIso8601StringFailure()
@@ -56,22 +56,22 @@ class DatePeriodFactoryTest extends \PHPUnit\Framework\TestCase
             $datesA[] = $dateTime->format("Y-m-dH:i");
         }
 
-        $this->assertEquals(
+        $this->assertCount(
             3,
-            count($datesA)
+            $datesA
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             date('YmdHi', strtotime($testDate  . '01:00 -1day')),
             date('YmdHi', strtotime($datesA[0]))
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             date('YmdHi', strtotime($testDate  . '01:00')),
             date('YmdHi', strtotime($datesA[1]))
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             date('YmdHi', strtotime($testDate  . '01:00 +1day')),
             date('YmdHi', strtotime($datesA[2]))
         );

--- a/test/unit/Component/DependencyInjection/ChapiConfigLoaderTest.php
+++ b/test/unit/Component/DependencyInjection/ChapiConfigLoaderTest.php
@@ -7,7 +7,7 @@
  *
  */
 
-namespace unit\Component\Config;
+namespace unit\Component\DependencyInjection;
 
 use Chapi\Component\DependencyInjection\Loader\ChapiConfigLoader;
 

--- a/test/unit/Component/Http/HttpGuzzleResponseTest.php
+++ b/test/unit/Component/Http/HttpGuzzleResponseTest.php
@@ -29,7 +29,7 @@ class HttpGuzzleResponseTest extends \PHPUnit\Framework\TestCase
 
         $httpGuzzleResponse = new HttpGuzzleResponse($this->responseInterface->reveal());
 
-        $this->assertEquals(200, $httpGuzzleResponse->getStatusCode());
+        $this->assertSame(200, $httpGuzzleResponse->getStatusCode());
     }
 
     public function testGetBodySuccess()
@@ -41,7 +41,7 @@ class HttpGuzzleResponseTest extends \PHPUnit\Framework\TestCase
 
         $httpGuzzleResponse = new HttpGuzzleResponse($this->responseInterface->reveal());
 
-        $this->assertEquals('string', $httpGuzzleResponse->getBody());
+        $this->assertSame('string', $httpGuzzleResponse->getBody());
     }
 
     public function testJsonSuccess()

--- a/test/unit/Component/RemoteClients/ChronosApiClientTest.php
+++ b/test/unit/Component/RemoteClients/ChronosApiClientTest.php
@@ -22,9 +22,6 @@ class ChronosApiClientTest extends \PHPUnit\Framework\TestCase
     /** @var \Prophecy\Prophecy\ObjectProphecy */
     private $httpResponse;
 
-    /**
-     *
-     */
     protected function setUp(): void
     {
         $this->httpClient = $this->prophesize('Chapi\Component\Http\HttpClientInterface');

--- a/test/unit/Entity/Chronos/JobEntityTest.php
+++ b/test/unit/Entity/Chronos/JobEntityTest.php
@@ -17,7 +17,7 @@ class JobEntityTest extends \PHPUnit\Framework\TestCase
     {
         $jobEntity = new ChronosJobEntity(['name' => 'jobname', 'unknownProperty' => 'value']);
 
-        $this->assertEquals('jobname', $jobEntity->name);
+        $this->assertSame('jobname', $jobEntity->name);
         $this->assertFalse(property_exists($jobEntity, 'unknownProperty'));
     }
 
@@ -48,10 +48,10 @@ class JobEntityTest extends \PHPUnit\Framework\TestCase
         ];
         $jobEntity = new ChronosJobEntity($data);
 
-        $this->assertEquals('jobname', $jobEntity->name);
-        $this->assertEquals('docker', $jobEntity->container->type);
-        $this->assertEquals('foo/bar', $jobEntity->container->image);
-        $this->assertTrue(is_array($jobEntity->container->volumes));
+        $this->assertSame('jobname', $jobEntity->name);
+        $this->assertSame('docker', $jobEntity->container->type);
+        $this->assertSame('foo/bar', $jobEntity->container->image);
+        $this->assertIsArray($jobEntity->container->volumes);
         $this->assertFalse(property_exists($jobEntity->container, 'unknownProperty'));
     }
 
@@ -118,8 +118,8 @@ class JobEntityTest extends \PHPUnit\Framework\TestCase
         $jobEntityTest = json_decode($jobEntityJson);
 
 
-        $this->assertEquals('jobname', $jobEntityTest->name);
-        $this->assertEquals('R/2015-07-07T01:00:00Z/P1D', $jobEntityTest->schedule);
+        $this->assertSame('jobname', $jobEntityTest->name);
+        $this->assertSame('R/2015-07-07T01:00:00Z/P1D', $jobEntityTest->schedule);
 
         $this->assertFalse(property_exists($jobEntityTest, 'parents'));
 
@@ -140,7 +140,7 @@ class JobEntityTest extends \PHPUnit\Framework\TestCase
         $jobEntityTest = json_decode($jobEntityJson);
 
 
-        $this->assertEquals('jobname', $jobEntityTest->name);
+        $this->assertSame('jobname', $jobEntityTest->name);
         $this->assertEquals(['jobA', 'jobB'], $jobEntityTest->parents);
 
         $this->assertFalse(property_exists($jobEntityTest, 'schedule'));
@@ -184,9 +184,9 @@ class JobEntityTest extends \PHPUnit\Framework\TestCase
             ]
         ]);
 
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($jobEntity->fetch)
+            $jobEntity->fetch
         );
         $this->assertTrue($jobEntity->fetch[0]->extract);
     }

--- a/test/unit/Entity/Marathon/AppEntity/ContainerTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/ContainerTest.php
@@ -30,7 +30,7 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
 
         $container = new Container($data);
 
-        $this->assertEquals("DOCKER", $container->type);
+        $this->assertSame("DOCKER", $container->type);
         $this->assertTrue(isset($container->docker));
         $this->assertTrue(isset($container->volumes));
         $this->assertTrue(isset($container->portMappings));

--- a/test/unit/Entity/Marathon/AppEntity/ContainerVolumeTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/ContainerVolumeTest.php
@@ -31,8 +31,8 @@ class ContainerVolumeTest extends \PHPUnit\Framework\TestCase
         ];
 
         $containerVolume = new ContainerVolume($data);
-        $this->assertEquals("some/container/path", $containerVolume->containerPath);
-        $this->assertEquals("some/host/path", $containerVolume->hostPath);
-        $this->assertEquals("RW", $containerVolume->mode);
+        $this->assertSame("some/container/path", $containerVolume->containerPath);
+        $this->assertSame("some/host/path", $containerVolume->hostPath);
+        $this->assertSame("RW", $containerVolume->mode);
     }
 }

--- a/test/unit/Entity/Marathon/AppEntity/DockerParametersTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/DockerParametersTest.php
@@ -29,7 +29,7 @@ class DockerParametersTest extends \PHPUnit\Framework\TestCase
 
         $dockerParameters = new DockerParameters($data);
 
-        $this->assertEquals("someKey", $dockerParameters->key);
-        $this->assertEquals("somevalue", $dockerParameters->value);
+        $this->assertSame("someKey", $dockerParameters->key);
+        $this->assertSame("somevalue", $dockerParameters->value);
     }
 }

--- a/test/unit/Entity/Marathon/AppEntity/DockerPortMappingTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/DockerPortMappingTest.php
@@ -34,9 +34,9 @@ class DockerPortMappingTest extends \PHPUnit\Framework\TestCase
 
         $dockerPortMapping = new DockerPortMapping($data);
 
-        $this->assertEquals(10010, $dockerPortMapping->hostPort);
-        $this->assertEquals(10011, $dockerPortMapping->containerPort);
-        $this->assertEquals(10211, $dockerPortMapping->servicePort);
-        $this->assertEquals("udp", $dockerPortMapping->protocol);
+        $this->assertSame(10010, $dockerPortMapping->hostPort);
+        $this->assertSame(10011, $dockerPortMapping->containerPort);
+        $this->assertSame(10211, $dockerPortMapping->servicePort);
+        $this->assertSame("udp", $dockerPortMapping->protocol);
     }
 }

--- a/test/unit/Entity/Marathon/AppEntity/DockerTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/DockerTest.php
@@ -26,7 +26,7 @@ class DockerTest extends \PHPUnit\Framework\TestCase
 
         $docker = new Docker($data);
 
-        $this->assertEquals("some/image", $docker->image);
+        $this->assertSame("some/image", $docker->image);
         $this->assertEquals(true, $docker->privileged);
 
         $this->assertTrue(isset($docker->parameters));

--- a/test/unit/Entity/Marathon/AppEntity/HealthCheckTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/HealthCheckTest.php
@@ -40,14 +40,14 @@ class HealthCheckTest extends \PHPUnit\Framework\TestCase
 
         $healthCheck = new HealthCheck($data);
 
-        $this->assertEquals("HTTP", $healthCheck->protocol);
-        $this->assertEquals("/health", $healthCheck->path);
-        $this->assertEquals(10, $healthCheck->gracePeriodSeconds);
-        $this->assertEquals(10, $healthCheck->intervalSeconds);
-        $this->assertEquals(2, $healthCheck->portIndex);
-        $this->assertEquals(8081, $healthCheck->port);
-        $this->assertEquals(40, $healthCheck->timeoutSeconds);
-        $this->assertEquals(4, $healthCheck->maxConsecutiveFailures);
+        $this->assertSame("HTTP", $healthCheck->protocol);
+        $this->assertSame("/health", $healthCheck->path);
+        $this->assertSame(10, $healthCheck->gracePeriodSeconds);
+        $this->assertSame(10, $healthCheck->intervalSeconds);
+        $this->assertSame(2, $healthCheck->portIndex);
+        $this->assertSame(8081, $healthCheck->port);
+        $this->assertSame(40, $healthCheck->timeoutSeconds);
+        $this->assertSame(4, $healthCheck->maxConsecutiveFailures);
         $this->assertTrue(isset($healthCheck->command));
     }
 
@@ -71,7 +71,7 @@ class HealthCheckTest extends \PHPUnit\Framework\TestCase
 
         $gotData = json_encode($healthCheck);
 
-        $this->assertEquals($expectedData, $gotData);
+        $this->assertSame($expectedData, $gotData);
     }
 
     public function testHealthCheckHasPortUnsetWithNullValue()
@@ -93,6 +93,6 @@ class HealthCheckTest extends \PHPUnit\Framework\TestCase
 
         $gotData = json_encode($healthCheck);
 
-        $this->assertEquals($expectedData, $gotData);
+        $this->assertSame($expectedData, $gotData);
     }
 }

--- a/test/unit/Entity/Marathon/AppEntity/IpAddressTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/IpAddressTest.php
@@ -31,11 +31,11 @@ class IpAddressTest extends \PHPUnit\Framework\TestCase
         ];
 
         $ipAddress = new IpAddress($data);
-        $this->assertEquals("datacenter", $ipAddress->networkName);
+        $this->assertSame("datacenter", $ipAddress->networkName);
         $this->assertEquals(["somegroup"], $ipAddress->groups);
         $this->assertTrue(isset($ipAddress->labels));
 
         $this->assertObjectHasAttribute("label1", $ipAddress->labels);
-        $this->assertEquals("somelabel", $ipAddress->labels->label1);
+        $this->assertSame("somelabel", $ipAddress->labels->label1);
     }
 }

--- a/test/unit/Entity/Marathon/AppEntity/PortDefinitionTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/PortDefinitionTest.php
@@ -27,7 +27,7 @@ class PortDefinitionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($portDefinition->name, "myport");
         $this->assertEquals($portDefinition->protocol, "udp");
         $this->assertObjectHasAttribute("key", $portDefinition->labels);
-        $this->assertEquals("somelabel", $portDefinition->labels->key);
+        $this->assertSame("somelabel", $portDefinition->labels->key);
     }
 
     public function testAllKeysAreCorrect()

--- a/test/unit/Entity/Marathon/AppEntity/UpgradeStrategyTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/UpgradeStrategyTest.php
@@ -31,7 +31,7 @@ class UpgradeStrategyTest extends \PHPUnit\Framework\TestCase
         ];
         $upgradeStrategy = new UpgradeStrategy($data);
 
-        $this->assertEquals(2, $upgradeStrategy->minimumHealthCapacity);
-        $this->assertEquals(3, $upgradeStrategy->maximumOverCapacity);
+        $this->assertSame(2, $upgradeStrategy->minimumHealthCapacity);
+        $this->assertSame(3, $upgradeStrategy->maximumOverCapacity);
     }
 }

--- a/test/unit/Service/Chronos/JobStatsServiceTest.php
+++ b/test/unit/Service/Chronos/JobStatsServiceTest.php
@@ -60,13 +60,13 @@ class JobStatsServiceTest extends \PHPUnit\Framework\TestCase
         $result = $jobStatsService->getJobStats('JobA');
 
         $this->assertInstanceOf('Chapi\Entity\Chronos\JobStatsEntity', $result);
-        $this->assertEquals($testResult['histogram']['75thPercentile'], $result->histogram->percentile75th);
-        $this->assertEquals($testResult['histogram']['95thPercentile'], $result->histogram->percentile95th);
-        $this->assertEquals($testResult['histogram']['98thPercentile'], $result->histogram->percentile98th);
-        $this->assertEquals($testResult['histogram']['99thPercentile'], $result->histogram->percentile99th);
-        $this->assertEquals($testResult['histogram']['median'], $result->histogram->median);
-        $this->assertEquals($testResult['histogram']['mean'], $result->histogram->mean);
-        $this->assertEquals($testResult['histogram']['count'], $result->histogram->count);
+        $this->assertSame($testResult['histogram']['75thPercentile'], $result->histogram->percentile75th);
+        $this->assertSame($testResult['histogram']['95thPercentile'], $result->histogram->percentile95th);
+        $this->assertSame($testResult['histogram']['98thPercentile'], $result->histogram->percentile98th);
+        $this->assertSame($testResult['histogram']['99thPercentile'], $result->histogram->percentile99th);
+        $this->assertSame($testResult['histogram']['median'], $result->histogram->median);
+        $this->assertSame($testResult['histogram']['mean'], $result->histogram->mean);
+        $this->assertSame($testResult['histogram']['count'], $result->histogram->count);
     }
 
     public function testGetJobStatsCacheSuccess()
@@ -94,13 +94,13 @@ class JobStatsServiceTest extends \PHPUnit\Framework\TestCase
         $result = $jobStatsService->getJobStats('JobA');
 
         $this->assertInstanceOf('Chapi\Entity\Chronos\JobStatsEntity', $result);
-        $this->assertEquals($testResult['histogram']['75thPercentile'], $result->histogram->percentile75th);
-        $this->assertEquals($testResult['histogram']['95thPercentile'], $result->histogram->percentile95th);
-        $this->assertEquals($testResult['histogram']['98thPercentile'], $result->histogram->percentile98th);
-        $this->assertEquals($testResult['histogram']['99thPercentile'], $result->histogram->percentile99th);
-        $this->assertEquals($testResult['histogram']['median'], $result->histogram->median);
-        $this->assertEquals($testResult['histogram']['mean'], $result->histogram->mean);
-        $this->assertEquals($testResult['histogram']['count'], $result->histogram->count);
+        $this->assertSame($testResult['histogram']['75thPercentile'], $result->histogram->percentile75th);
+        $this->assertSame($testResult['histogram']['95thPercentile'], $result->histogram->percentile95th);
+        $this->assertSame($testResult['histogram']['98thPercentile'], $result->histogram->percentile98th);
+        $this->assertSame($testResult['histogram']['99thPercentile'], $result->histogram->percentile99th);
+        $this->assertSame($testResult['histogram']['median'], $result->histogram->median);
+        $this->assertSame($testResult['histogram']['mean'], $result->histogram->mean);
+        $this->assertSame($testResult['histogram']['count'], $result->histogram->count);
     }
 
     public function testDoNotCacheEmptyResults()
@@ -118,7 +118,7 @@ class JobStatsServiceTest extends \PHPUnit\Framework\TestCase
         $result = $jobStatsService->getJobStats('JobA');
 
         $this->assertInstanceOf('Chapi\Entity\Chronos\JobStatsEntity', $result);
-        $this->assertEquals(0.0, $result->histogram->percentile75th);
-        $this->assertEquals(0, $result->histogram->count);
+        $this->assertSame(0.0, $result->histogram->percentile75th);
+        $this->assertSame(0, $result->histogram->count);
     }
 }

--- a/test/unit/Service/JobDependency/JobDependencyServiceTest.php
+++ b/test/unit/Service/JobDependency/JobDependencyServiceTest.php
@@ -44,8 +44,8 @@ class JobDependencyServiceTest extends \PHPUnit\Framework\TestCase
         $jobDependencyService = new JobDependencyService($this->jobRepositoryLocal->reveal(), $this->jobRepositoryChronos->reveal());
         $result = $jobDependencyService->getChildJobs('JobA', JobDependencyService::REPOSITORY_LOCAL);
 
-        $this->assertTrue(is_array($result));
-        $this->assertTrue(in_array('JobB', $result));
+        $this->assertIsArray($result);
+        $this->assertContains('JobB', $result);
 
         $this->assertTrue($jobDependencyService->hasChildJobs('JobA', JobDependencyService::REPOSITORY_LOCAL));
         $this->assertFalse($jobDependencyService->hasChildJobs('JobB', JobDependencyService::REPOSITORY_LOCAL));
@@ -59,8 +59,8 @@ class JobDependencyServiceTest extends \PHPUnit\Framework\TestCase
         $jobDependencyService = new JobDependencyService($this->jobRepositoryLocal->reveal(), $this->jobRepositoryChronos->reveal());
         $result = $jobDependencyService->getChildJobs('JobA', JobDependencyService::REPOSITORY_CHRONOS);
 
-        $this->assertTrue(is_array($result));
-        $this->assertTrue(in_array('JobB', $result));
+        $this->assertIsArray($result);
+        $this->assertContains('JobB', $result);
 
         $this->assertTrue($jobDependencyService->hasChildJobs('JobA', JobDependencyService::REPOSITORY_CHRONOS));
         $this->assertFalse($jobDependencyService->hasChildJobs('JobB', JobDependencyService::REPOSITORY_CHRONOS));

--- a/test/unit/Service/JobRepository/BridgeFileSystemTest.php
+++ b/test/unit/Service/JobRepository/BridgeFileSystemTest.php
@@ -100,9 +100,9 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
         );
 
         $jobs = $fileSystemRepository->getJobs();
-        $this->assertEquals(
+        $this->assertCount(
             4,
-            count($jobs)
+            $jobs
         );
 
         $this->assertInstanceOf('Chapi\Entity\JobEntityInterface', $jobs[0]);
@@ -124,9 +124,9 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
         );
 
         $entities = $fileSystemRepository->getJobs();
-        $this->assertEquals(
+        $this->assertCount(
             2,
-            count($entities)
+            $entities
         );
 
         $countMarathon = 0;
@@ -145,8 +145,8 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
             }
         }
 
-        $this->assertEquals(1, $countChronos, "Expected 1 chronos job, got $countChronos");
-        $this->assertEquals(1, $countMarathon, "Expected 1 marathon app, got $countMarathon");
+        $this->assertSame(1, $countChronos, "Expected 1 chronos job, got $countChronos");
+        $this->assertSame(1, $countMarathon, "Expected 1 marathon app, got $countMarathon");
     }
 
     public function testAddUpdateRemoveChronosJobSuccess()
@@ -163,20 +163,20 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
 
         // first check and init
         $jobs = $fileSystemRepository->getJobs();
-        $this->assertEquals(
+        $this->assertCount(
             0,
-            count($jobs),
+            $jobs,
             'Expected "0" jobs at first run'
         );
 
         // add job
         $this->assertTrue($fileSystemRepository->addJob($entity));
-        $this->assertTrue(file_exists($this->tempTestDir . DIRECTORY_SEPARATOR . 'JobX.json'));
+        $this->assertFileExists($this->tempTestDir . DIRECTORY_SEPARATOR . 'JobX.json');
 
         $jobs = $fileSystemRepository->getJobs();
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($jobs),
+            $jobs,
             'Expected "1" job after adding'
         );
 
@@ -192,23 +192,23 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($fileSystemRepository->updateJob($entity));
 
         $jobs = $fileSystemRepository->getJobs();
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($jobs),
+            $jobs,
             'Expected still "1" job after update'
         );
 
-        $this->assertEquals(123, $jobs[0]->mem);
+        $this->assertSame(123, $jobs[0]->mem);
         $this->assertTrue($jobs[0]->disabled);
 
         // remove job
         $this->assertTrue($fileSystemRepository->removeJob($entity));
-        $this->assertFalse(file_exists($this->tempTestDir . DIRECTORY_SEPARATOR . 'JobX.json'));
+        $this->assertFileNotExists($this->tempTestDir . DIRECTORY_SEPARATOR . 'JobX.json');
 
         $jobs = $fileSystemRepository->getJobs();
-        $this->assertEquals(
+        $this->assertCount(
             0,
-            count($jobs),
+            $jobs,
             'Expected "0" jobs after deletion'
         );
     }
@@ -227,20 +227,20 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
 
         // first check and init
         $jobs = $fileSystemRepository->getJobs();
-        $this->assertEquals(
+        $this->assertCount(
             0,
-            count($jobs),
+            $jobs,
             'Expected "0" app at first run'
         );
 
         // add app
         $this->assertTrue($fileSystemRepository->addJob($appEntity));
-        $this->assertTrue(file_exists($this->tempTestDir. DIRECTORY_SEPARATOR. 'testgroup'. DIRECTORY_SEPARATOR .'testapp.json'));
+        $this->assertFileExists($this->tempTestDir. DIRECTORY_SEPARATOR. 'testgroup'. DIRECTORY_SEPARATOR .'testapp.json');
 
         $jobs = $fileSystemRepository->getJobs();
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($jobs),
+            $jobs,
             'Expected "1" app after adding'
         );
 
@@ -256,23 +256,23 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($fileSystemRepository->updateJob($appEntity));
 
         $jobs = $fileSystemRepository->getJobs();
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($jobs),
+            $jobs,
             'Expected still "1" job after update'
         );
 
-        $this->assertEquals(2, $jobs[0]->cpus);
-        $this->assertEquals(1024, $jobs[0]->mem);
+        $this->assertSame(2, $jobs[0]->cpus);
+        $this->assertSame(1024, $jobs[0]->mem);
 
         // remove job
         $this->assertTrue($fileSystemRepository->removeJob($appEntity));
-        $this->assertFalse(file_exists($this->tempTestDir . DIRECTORY_SEPARATOR . 'testgroup'. DIRECTORY_SEPARATOR .'testapp.json'));
+        $this->assertFileNotExists($this->tempTestDir . DIRECTORY_SEPARATOR . 'testgroup'. DIRECTORY_SEPARATOR .'testapp.json');
 
         $jobs = $fileSystemRepository->getJobs();
-        $this->assertEquals(
+        $this->assertCount(
             0,
-            count($jobs),
+            $jobs,
             'Expected "0" jobs after deletion'
         );
     }
@@ -296,7 +296,7 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
         );
 
         $apps = $fileSystemRepository->getJobs();
-        $this->assertEquals(2, count($apps), "Expected 2 app, got ".count($apps));
+        $this->assertCount(2, $apps, "Expected 2 app, got ".count($apps));
 
         $updatedKey = $apps[0]->getKey();
         $apps[0]->mem = 1024;
@@ -305,17 +305,17 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($fileSystemRepository->updateJob($apps[0]), 'UpdateJob returned false, expected true');
 
         $appsAfterModification = $fileSystemRepository->getJobs();
-        $this->assertEquals(2, count($apps), "Expected 2 apps, got " . count($appsAfterModification));
+        $this->assertCount(2, $apps, "Expected 2 apps, got " . count($appsAfterModification));
 
         foreach ($appsAfterModification as $app) {
             if ($app->getKey() == $updatedKey) {
-                $this->assertEquals(
+                $this->assertSame(
                     1024,
                     $app->mem,
                     "Expected 1024, got $app->mem"
                 );
 
-                $this->assertEquals(
+                $this->assertSame(
                     2,
                     $app->cpus,
                     "Expected 2, got $app->cpus"
@@ -344,13 +344,13 @@ class BridgeFileSystemTest extends \PHPUnit\Framework\TestCase
         );
 
         $jobs = $fileSystemRepository->getJobs();
-        $this->assertEquals(2, count($jobs), 'Expected 2 app before removal, found '.count($jobs));
+        $this->assertCount(2, $jobs, 'Expected 2 app before removal, found '.count($jobs));
 
         $fileSystemRepository->removeJob($groupConfig["apps"][0]);
 
         $remainingApps = $fileSystemRepository->getJobs();
 
-        $this->assertEquals(1, count($remainingApps), 'Expected 1 app remaining after removal, found ' . count($remainingApps));
+        $this->assertCount(1, $remainingApps, 'Expected 1 app remaining after removal, found ' . count($remainingApps));
     }
 
     public function testJobLoadException()

--- a/test/unit/Service/JobRepository/JobRepositoryTest.php
+++ b/test/unit/Service/JobRepository/JobRepositoryTest.php
@@ -59,7 +59,7 @@ class JobRepositoryTest extends \PHPUnit\Framework\TestCase
             $jobEntity
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'JobA',
             $jobEntity->name
         );
@@ -214,7 +214,7 @@ class JobRepositoryTest extends \PHPUnit\Framework\TestCase
         $jobEntityResult = $jobRepository->getJob('JobA');
 
         // known job
-        $this->assertEquals(
+        $this->assertSame(
             'JobA',
             $jobEntityResult->name
         );

--- a/test/unit/Service/JobValidator/JobEntityValidatorServiceTest.php
+++ b/test/unit/Service/JobValidator/JobEntityValidatorServiceTest.php
@@ -94,9 +94,9 @@ class JobEntityValidatorServiceTest extends \PHPUnit\Framework\TestCase
         );
 
         // test
-        $this->assertEquals(
+        $this->assertCount(
             0,
-            count($jobEntityValidatorService->getInvalidProperties($jobEntity))
+            $jobEntityValidatorService->getInvalidProperties($jobEntity)
         );
     }
 
@@ -123,7 +123,7 @@ class JobEntityValidatorServiceTest extends \PHPUnit\Framework\TestCase
         );
 
         foreach ($result as $errorMessage) {
-            $this->assertEquals('error message', $errorMessage);
+            $this->assertSame('error message', $errorMessage);
             break; // one check is enough
         }
     }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assert equals strict.
- Using the current assertions to do assertions.
- It seems that this package is for `php-7.2` version test during Travis CI build at least. And it should require `php-7.2` version at least.
- And it should let `Dockerfile` require `php-7.2` version to build the Docker image. I think it's another PR.